### PR TITLE
WIP: Restore original implementation of as_nlists.mcmcr()

### DIFF
--- a/R/as-nlists.R
+++ b/R/as-nlists.R
@@ -4,5 +4,8 @@ nlist::as_nlists
 #' @inherit nlist::as_nlists
 #' @export
 as_nlists.mcmcr <- function(x, ...) {
-  as_nlists(as_mcmc_list(x))
+  chk_identical(nchains(x), 1L)
+  x <- lapply(1:niters(x), FUN = subset_iteration_mcmcr, x)
+  x <- lapply(x, set_class, "nlist")
+  set_class(x, "nlists")
 }


### PR DESCRIPTION
This fixes the performance problem by reverting to the original implementation. For the simple example the results didn't change. I don't understand the implications of this.

Closes #47.