### PR TITLE
fledge: CRAN pre-release v0.6.1.9900

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcmcr
 Title: Manipulate MCMC Samples
-Version: 0.6.1.9003
+Version: 0.6.1.9900
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcmcr
 Title: Manipulate MCMC Samples
-Version: 0.6.1.9900
+Version: 0.6.2
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# mcmcr 0.6.1.9003
+# mcmcr 0.6.1.9900
 
 - Depends on R \>= 4.0.
 - When `bound = TRUE` `rhat()` now also returns rhat values for separate analyses.
 - When `bound = TRUE` and `as_df = TRUE` `rhat()` now returns a data.frame with the rhat values for the separate and combined analyses.
+
 
 # mcmcr 0.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# mcmcr 0.6.1.9900
+# mcmcr 0.6.2
 
 - Depends on R \>= 4.0.
 - When `bound = TRUE` `rhat()` now also returns rhat values for separate analyses.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,21 +1,5 @@
-## Test environments
+mcmcr 0.6.1.9900
 
-release 4.1.1
+## Cran Repository Policy
 
-* OSX (local) - release
-* OSX (actions) - release
-* Ubuntu (actions) - 3.5 to 3.6, oldrel, release and devel
-* Windows (actions) - release
-* Windows (winbuilder) - devel
-
-## R CMD check results
-
-0 errors | 0 warnings | 0 notes
-
-## revdepcheck results
-
-We checked 2 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
-
- * We saw 0 new problems
- * We failed to check 0 packages
-
+- [x] Reviewed CRP last edited 2024-08-27.


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-01-23, no problems found.

## Action items

- [x] Review PR
- [x] Await successful CI/CD run
- [x] Run `fledge::release()`
- [x] When the package is accepted on CRAN, run `fledge::post_release()`