### PR TITLE
Escalate 0.2.1 deprecations from deprecate_soft() to deprecate_warn()

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -245,7 +245,7 @@ importFrom(extras,
 importFrom(generics,tidy)
 importFrom(graphics,plot)
 importFrom(lifecycle,
-  deprecate_soft,
+  deprecate_warn,
   deprecated
 )
 importFrom(nlist,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -227,50 +227,64 @@ import(extras)
 import(nlist)
 import(term)
 import(universals)
-importFrom(coda,as.mcmc)
-importFrom(coda,as.mcmc.list)
-importFrom(coda,mcmc.list)
-importFrom(coda,thin)
-importFrom(extras,fill_all)
-importFrom(extras,fill_na)
-importFrom(extras,lower)
-importFrom(extras,pvalue)
-importFrom(extras,svalue)
-importFrom(extras,upper)
-importFrom(extras,zscore)
+importFrom(coda,
+  as.mcmc,
+  as.mcmc.list,
+  mcmc.list,
+  thin
+)
+importFrom(extras,
+  fill_all,
+  fill_na,
+  lower,
+  pvalue,
+  svalue,
+  upper,
+  zscore
+)
 importFrom(generics,tidy)
 importFrom(graphics,plot)
-importFrom(lifecycle,deprecate_soft)
-importFrom(lifecycle,deprecated)
-importFrom(nlist,as_nlist)
-importFrom(nlist,as_nlists)
-importFrom(nlist,nlist)
-importFrom(nlist,nlists)
-importFrom(stats,coef)
-importFrom(stats,median)
-importFrom(stats,na.pass)
-importFrom(stats,terms)
-importFrom(term,"parameters<-")
-importFrom(term,as.term)
-importFrom(term,as_term)
-importFrom(term,complete_terms)
-importFrom(term,parameters)
+importFrom(lifecycle,
+  deprecate_soft,
+  deprecated
+)
+importFrom(nlist,
+  as_nlist,
+  as_nlists,
+  nlist,
+  nlists
+)
+importFrom(stats,
+  coef,
+  median,
+  na.pass,
+  terms
+)
+importFrom(term,
+  "parameters<-",
+  as.term,
+  as_term,
+  complete_terms,
+  parameters
+)
 importFrom(tibble,tibble)
-importFrom(universals,"pars<-")
-importFrom(universals,bind_chains)
-importFrom(universals,bind_iterations)
-importFrom(universals,collapse_chains)
-importFrom(universals,converged)
-importFrom(universals,dims)
-importFrom(universals,esr)
-importFrom(universals,estimates)
-importFrom(universals,nchains)
-importFrom(universals,niters)
-importFrom(universals,npars)
-importFrom(universals,npdims)
-importFrom(universals,nterms)
-importFrom(universals,pars)
-importFrom(universals,pdims)
-importFrom(universals,rhat)
-importFrom(universals,set_pars)
-importFrom(universals,split_chains)
+importFrom(universals,
+  "pars<-",
+  bind_chains,
+  bind_iterations,
+  collapse_chains,
+  converged,
+  dims,
+  esr,
+  estimates,
+  nchains,
+  niters,
+  npars,
+  npdims,
+  nterms,
+  pars,
+  pdims,
+  rhat,
+  set_pars,
+  split_chains
+)

--- a/R/check.R
+++ b/R/check.R
@@ -10,7 +10,7 @@
 #' @examples
 #' check_mcmcarray(mcmcr::mcmcr_example$beta)
 check_mcmcarray <- function(x, x_name = substitute(x), error = TRUE) {
-  lifecycle::deprecate_soft("v0.2.1", "check_mcmcarray()", "chk_mcmcarray()")
+  lifecycle::deprecate_warn("0.2.1", "check_mcmcarray()", "chk_mcmcarray()")
   x_name <- deparse_backtick_chk(x_name)
   chk_string(x_name)
   chk_flag(error)
@@ -33,7 +33,7 @@ check_mcmcarray <- function(x, x_name = substitute(x), error = TRUE) {
 #' @examples
 #' check_mcmcr(mcmcr::mcmcr_example)
 check_mcmcr <- function(x, sorted = FALSE, x_name = substitute(x), error = TRUE) {
-  lifecycle::deprecate_soft("v0.2.1", "check_mcmcr()", "chk_mcmcr()")
+  lifecycle::deprecate_warn("0.2.1", "check_mcmcr()", "chk_mcmcr()")
   x_name <- deparse_backtick_chk(x_name)
   chk_flag(sorted)
   chk_string(x_name)

--- a/R/mcmcr-package.R
+++ b/R/mcmcr-package.R
@@ -4,7 +4,7 @@
 # The following block is used by usethis to automatically manage
 # roxygen namespace tags. Modify with care!
 ## usethis namespace: start
-#' @importFrom lifecycle deprecate_soft
+#' @importFrom lifecycle deprecate_warn
 #' @importFrom tibble tibble
 #' @importFrom lifecycle deprecated
 ## usethis namespace: end

--- a/R/pars.R
+++ b/R/pars.R
@@ -22,7 +22,7 @@ pars.mcmcr <- function(x, scalar = NULL, terms = FALSE, ...) {
   chk_unused(...)
 
   if (!missing(terms)) {
-    deprecate_soft("0.2.1", "mcmcr::pars(terms =)", details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)...`.", id = "pars_terms")
+    deprecate_warn("0.2.1", "mcmcr::pars(terms =)", details = "If `terms = TRUE` use `term::pars_terms(as_term(x))` otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.", id = "pars_terms")
   }
   pars_impl(x, scalar, terms)
 }
@@ -36,7 +36,7 @@ pars.mcmcrs <- function(x, scalar = NULL, terms = FALSE, ...) {
   chk_unused(...)
 
   if (!missing(terms)) {
-    deprecate_soft("0.2.1", "mcmcr::pars(terms =)", details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.", id = "pars_terms")
+    deprecate_warn("0.2.1", "mcmcr::pars(terms =)", details = "If `terms = TRUE` use `term::pars_terms(as_term(x))` otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.", id = "pars_terms")
   }
   pars_impl(x[[1]], scalar = scalar, terms = terms, ...)
 }

--- a/R/subset.R
+++ b/R/subset.R
@@ -19,7 +19,7 @@ NULL
 subset.mcmcarray <- function(x, chains = NULL, iters = NULL,
                              iterations = NULL, ...) {
   if (!missing(iterations)) {
-    deprecate_soft("0.2.1", "subset(iterations = )", "subset(iters = )",
+    deprecate_warn("0.2.1", "subset(iterations = )", "subset(iters = )",
       id = "subset_iterations"
     )
     iters <- iterations
@@ -47,13 +47,13 @@ subset.mcmcarray <- function(x, chains = NULL, iters = NULL,
 subset.mcmcr <- function(x, chains = NULL, iters = NULL, pars = NULL,
                          iterations = NULL, parameters = NULL, ...) {
   if (!missing(iterations)) {
-    deprecate_soft("0.2.1", "subset(iterations = )", "subset(iters = )",
+    deprecate_warn("0.2.1", "subset(iterations = )", "subset(iters = )",
       id = "subset_iterations"
     )
     iters <- iterations
   }
   if (!missing(parameters)) {
-    deprecate_soft("0.2.1", "subset(parameters = )", "subset(pars = )",
+    deprecate_warn("0.2.1", "subset(parameters = )", "subset(pars = )",
       id = "subset_parameters"
     )
     pars <- parameters
@@ -77,13 +77,13 @@ subset.mcmcr <- function(x, chains = NULL, iters = NULL, pars = NULL,
 subset.mcmcrs <- function(x, chains = NULL, iters = NULL, pars = NULL,
                           iterations = NULL, parameters = NULL, ...) {
   if (!missing(iterations)) {
-    deprecate_soft("0.2.1", "subset(iterations = )", "subset(iters = )",
+    deprecate_warn("0.2.1", "subset(iterations = )", "subset(iters = )",
       id = "subset_iterations"
     )
     iters <- iterations
   }
   if (!missing(parameters)) {
-    deprecate_soft("0.2.1", "subset(parameters = )", "subset(pars = )",
+    deprecate_warn("0.2.1", "subset(parameters = )", "subset(pars = )",
       id = "subset_parameters"
     )
     pars <- parameters

--- a/R/terms.R
+++ b/R/terms.R
@@ -1,23 +1,23 @@
 #' @export
 terms.mcmc <- function(x, ...) {
-  deprecate_soft("0.2.1", "terms()", "as_term()", id = "terms")
+  deprecate_warn("0.2.1", "terms()", "as_term()", id = "terms")
   as_term(x)
 }
 
 #' @export
 terms.mcmc.list <- function(x, ...) {
-  deprecate_soft("0.2.1", "terms()", "as_term()", id = "terms")
+  deprecate_warn("0.2.1", "terms()", "as_term()", id = "terms")
   as_term(x)
 }
 
 #' @export
 terms.mcmcarray <- function(x, ...) {
-  deprecate_soft("0.2.1", "terms()", "as_term()", id = "terms")
+  deprecate_warn("0.2.1", "terms()", "as_term()", id = "terms")
   as_term(x)
 }
 
 #' @export
 terms.mcmcr <- function(x, ...) {
-  deprecate_soft("0.2.1", "terms()", "as_term()", id = "terms")
+  deprecate_warn("0.2.1", "terms()", "as_term()", id = "terms")
   as_term(x)
 }

--- a/R/zero.R
+++ b/R/zero.R
@@ -13,7 +13,7 @@
 #' @examples
 #' zero(mcmcr_example, pars = "beta")
 zero <- function(x, ...) {
-  lifecycle::deprecate_soft("v0.2.1", "zero()", "fill_all()")
+  lifecycle::deprecate_warn("0.2.1", "zero()", "fill_all()")
   UseMethod("zero")
 }
 

--- a/man/as.mcarray.Rd
+++ b/man/as.mcarray.Rd
@@ -26,9 +26,9 @@ Coerces MCMC objects to an mcarray object.
 as.mcarray(mcmcr_example$beta)
 }
 \seealso{
-Other coerce: 
-\code{\link{as.mcmcarray}()},
-\code{\link{as.mcmcr}()},
-\code{\link{mcmcrs}()}
+Other coerce:
+\code{\link[=as.mcmcarray]{as.mcmcarray()}},
+\code{\link[=as.mcmcr]{as.mcmcr()}},
+\code{\link[=mcmcrs]{mcmcrs()}}
 }
 \concept{coerce}

--- a/man/as.mcmcarray.Rd
+++ b/man/as.mcmcarray.Rd
@@ -18,9 +18,9 @@ Coerces MCMC objects to an \code{\link[=mcmcarray-object]{mcmcarray-object()}}.
 as.mcmcarray(as.mcarray(mcmcr_example$beta))
 }
 \seealso{
-Other coerce: 
-\code{\link{as.mcarray}()},
-\code{\link{as.mcmcr}()},
-\code{\link{mcmcrs}()}
+Other coerce:
+\code{\link[=as.mcarray]{as.mcarray()}},
+\code{\link[=as.mcmcr]{as.mcmcr()}},
+\code{\link[=mcmcrs]{mcmcrs()}}
 }
 \concept{coerce}

--- a/man/as.mcmcr.Rd
+++ b/man/as.mcmcr.Rd
@@ -46,9 +46,9 @@ Converts an MCMC object to an \code{\link[=mcmcr-object]{mcmcr-object()}}.
 
 \item \code{as.mcmcr(mcmcarray)}: Convert an \code{\link[=mcmcarray-object]{mcmcarray-object()}} to an mcmcr object
 
-\item \code{as.mcmcr(nlist)}: Convert an \code{\link[nlist:nlist]{nlist::nlist-object()}} to an mcmcr object
+\item \code{as.mcmcr(nlist)}: Convert an \code{\link[nlist:nlist-object]{nlist::nlist-object()}} to an mcmcr object
 
-\item \code{as.mcmcr(nlists)}: Convert an \code{\link[nlist:nlists]{nlist::nlists-object()}} to an mcmcr object
+\item \code{as.mcmcr(nlists)}: Convert an \code{\link[nlist:nlists-object]{nlist::nlists-object()}} to an mcmcr object
 
 \item \code{as.mcmcr(mcmc)}: Convert an \code{\link[coda:mcmc]{coda::mcmc()}} object to an mcmcr object
 
@@ -62,9 +62,9 @@ mcmc.list <- coda::as.mcmc.list(mcmcr::mcmcr_example)
 as.mcmcr(mcmc.list)
 }
 \seealso{
-Other coerce: 
-\code{\link{as.mcarray}()},
-\code{\link{as.mcmcarray}()},
-\code{\link{mcmcrs}()}
+Other coerce:
+\code{\link[=as.mcarray]{as.mcarray()}},
+\code{\link[=as.mcmcarray]{as.mcmcarray()}},
+\code{\link[=mcmcrs]{mcmcrs()}}
 }
 \concept{coerce}

--- a/man/as_nlist.mcmcr.Rd
+++ b/man/as_nlist.mcmcr.Rd
@@ -38,6 +38,6 @@ as_nlist(list(x = 1:4))
 as_nlist(c(`a[2]` = 3, `a[1]` = 2))
 }
 \seealso{
-Other coerce: 
-\code{\link[nlist]{as_nlists}()}
+Other coerce:
+\code{\link[nlist:as_nlists]{as_nlists()}}
 }

--- a/man/as_nlists.mcmcr.Rd
+++ b/man/as_nlists.mcmcr.Rd
@@ -35,6 +35,6 @@ Coerce an R object to an \code{\link[nlist:nlists_object]{nlists_object()}}.
 as_nlists(list(nlist(x = c(1, 5)), nlist(x = c(2, 3)), nlist(x = c(3, 2))))
 }
 \seealso{
-Other coerce: 
-\code{\link[nlist]{as_nlist}()}
+Other coerce:
+\code{\link[nlist:as_nlist]{as_nlist()}}
 }

--- a/man/bind_dimensions.Rd
+++ b/man/bind_dimensions.Rd
@@ -25,8 +25,8 @@ bind_dimensions(mcmcr_example, mcmcr_example)
 \seealso{
 \code{\link[universals:bind_chains]{universals::bind_chains()}}
 
-Other bind: 
-\code{\link{bind_dimensions_n}()},
-\code{\link{bind_parameters}()}
+Other bind:
+\code{\link[=bind_dimensions_n]{bind_dimensions_n()}},
+\code{\link[=bind_parameters]{bind_parameters()}}
 }
 \concept{bind}

--- a/man/bind_dimensions_n.Rd
+++ b/man/bind_dimensions_n.Rd
@@ -18,8 +18,8 @@ bind_dimensions_n(mcmcr_example, mcmcr_example, mcmcr_example)
 \seealso{
 \code{\link[universals:bind_chains]{universals::bind_chains()}}
 
-Other bind: 
-\code{\link{bind_dimensions}()},
-\code{\link{bind_parameters}()}
+Other bind:
+\code{\link[=bind_dimensions]{bind_dimensions()}},
+\code{\link[=bind_parameters]{bind_parameters()}}
 }
 \concept{bind}

--- a/man/bind_parameters.Rd
+++ b/man/bind_parameters.Rd
@@ -25,8 +25,8 @@ bind_parameters(
 \seealso{
 \code{\link[universals:bind_chains]{universals::bind_chains()}}
 
-Other bind: 
-\code{\link{bind_dimensions}()},
-\code{\link{bind_dimensions_n}()}
+Other bind:
+\code{\link[=bind_dimensions]{bind_dimensions()}},
+\code{\link[=bind_dimensions_n]{bind_dimensions_n()}}
 }
 \concept{bind}

--- a/man/combine_dimensions.Rd
+++ b/man/combine_dimensions.Rd
@@ -25,8 +25,8 @@ Combines MCMC object samples by dimensions along \code{along} using \code{fun}.
 combine_dimensions(mcmcr_example$alpha)
 }
 \seealso{
-Other combine: 
-\code{\link{combine_samples}()},
-\code{\link{combine_samples_n}()}
+Other combine:
+\code{\link[=combine_samples]{combine_samples()}},
+\code{\link[=combine_samples_n]{combine_samples_n()}}
 }
 \concept{combine}

--- a/man/combine_samples.Rd
+++ b/man/combine_samples.Rd
@@ -28,8 +28,8 @@ Combines samples of two MCMC objects
 combine_samples(mcmcr_example, mcmcr_example, fun = sum)
 }
 \seealso{
-Other combine: 
-\code{\link{combine_dimensions}()},
-\code{\link{combine_samples_n}()}
+Other combine:
+\code{\link[=combine_dimensions]{combine_dimensions()}},
+\code{\link[=combine_samples_n]{combine_samples_n()}}
 }
 \concept{combine}

--- a/man/combine_samples_n.Rd
+++ b/man/combine_samples_n.Rd
@@ -21,8 +21,8 @@ Combines samples of multiple MCMC objects
 combine_samples_n(mcmcr_example, mcmcr_example, mcmcr_example, fun = sum)
 }
 \seealso{
-Other combine: 
-\code{\link{combine_dimensions}()},
-\code{\link{combine_samples}()}
+Other combine:
+\code{\link[=combine_dimensions]{combine_dimensions()}},
+\code{\link[=combine_samples]{combine_samples()}}
 }
 \concept{combine}

--- a/man/fill_all.mcarray.Rd
+++ b/man/fill_all.mcarray.Rd
@@ -57,6 +57,6 @@ fill_all(c(1, 4, NA), value = TRUE, nas = FALSE)
 fill_all(c("some", "words"), value = TRUE)
 }
 \seealso{
-Other fill: 
-\code{\link[extras]{fill_na}()}
+Other fill:
+\code{\link[extras:fill_na]{fill_na()}}
 }

--- a/man/fill_all.mcmcarray.Rd
+++ b/man/fill_all.mcmcarray.Rd
@@ -57,6 +57,6 @@ fill_all(c(1, 4, NA), value = TRUE, nas = FALSE)
 fill_all(c("some", "words"), value = TRUE)
 }
 \seealso{
-Other fill: 
-\code{\link[extras]{fill_na}()}
+Other fill:
+\code{\link[extras:fill_na]{fill_na()}}
 }

--- a/man/fill_all.mcmcr.Rd
+++ b/man/fill_all.mcmcr.Rd
@@ -57,6 +57,6 @@ fill_all(c(1, 4, NA), value = TRUE, nas = FALSE)
 fill_all(c("some", "words"), value = TRUE)
 }
 \seealso{
-Other fill: 
-\code{\link[extras]{fill_na}()}
+Other fill:
+\code{\link[extras:fill_na]{fill_na()}}
 }

--- a/man/fill_na.mcarray.Rd
+++ b/man/fill_na.mcarray.Rd
@@ -53,6 +53,6 @@ fill_na(c("text", NA))
 fill_na(matrix(c("text", NA)), value = Inf)
 }
 \seealso{
-Other fill: 
-\code{\link[extras]{fill_all}()}
+Other fill:
+\code{\link[extras:fill_all]{fill_all()}}
 }

--- a/man/fill_na.mcmcarray.Rd
+++ b/man/fill_na.mcmcarray.Rd
@@ -53,6 +53,6 @@ fill_na(c("text", NA))
 fill_na(matrix(c("text", NA)), value = Inf)
 }
 \seealso{
-Other fill: 
-\code{\link[extras]{fill_all}()}
+Other fill:
+\code{\link[extras:fill_all]{fill_all()}}
 }

--- a/man/fill_na.mcmcr.Rd
+++ b/man/fill_na.mcmcr.Rd
@@ -53,6 +53,6 @@ fill_na(c("text", NA))
 fill_na(matrix(c("text", NA)), value = Inf)
 }
 \seealso{
-Other fill: 
-\code{\link[extras]{fill_all}()}
+Other fill:
+\code{\link[extras:fill_all]{fill_all()}}
 }

--- a/man/is.mcarray.Rd
+++ b/man/is.mcarray.Rd
@@ -19,9 +19,9 @@ Tests whether an object is an mcarray.
 is.mcarray(mcmcr_example)
 }
 \seealso{
-Other is: 
-\code{\link{is.mcmcarray}()},
-\code{\link{is.mcmcr}()},
-\code{\link{is.mcmcrs}()}
+Other is:
+\code{\link[=is.mcmcarray]{is.mcmcarray()}},
+\code{\link[=is.mcmcr]{is.mcmcr()}},
+\code{\link[=is.mcmcrs]{is.mcmcrs()}}
 }
 \concept{is}

--- a/man/is.mcmcarray.Rd
+++ b/man/is.mcmcarray.Rd
@@ -19,9 +19,9 @@ Tests whether an object is an \code{\link[=mcmcarray-object]{mcmcarray-object()}
 is.mcmcarray(mcmcr_example$beta)
 }
 \seealso{
-Other is: 
-\code{\link{is.mcarray}()},
-\code{\link{is.mcmcr}()},
-\code{\link{is.mcmcrs}()}
+Other is:
+\code{\link[=is.mcarray]{is.mcarray()}},
+\code{\link[=is.mcmcr]{is.mcmcr()}},
+\code{\link[=is.mcmcrs]{is.mcmcrs()}}
 }
 \concept{is}

--- a/man/is.mcmcr.Rd
+++ b/man/is.mcmcr.Rd
@@ -19,9 +19,9 @@ Tests whether an object is an \code{\link[=mcmcr-object]{mcmcr-object()}}.
 is.mcmcr(mcmcr_example)
 }
 \seealso{
-Other is: 
-\code{\link{is.mcarray}()},
-\code{\link{is.mcmcarray}()},
-\code{\link{is.mcmcrs}()}
+Other is:
+\code{\link[=is.mcarray]{is.mcarray()}},
+\code{\link[=is.mcmcarray]{is.mcmcarray()}},
+\code{\link[=is.mcmcrs]{is.mcmcrs()}}
 }
 \concept{is}

--- a/man/is.mcmcrs.Rd
+++ b/man/is.mcmcrs.Rd
@@ -19,9 +19,9 @@ Tests whether an object is an \code{\link[=mcmcrs-object]{mcmcrs-object()}}.
 is.mcmcrs(mcmcrs(mcmcr_example))
 }
 \seealso{
-Other is: 
-\code{\link{is.mcarray}()},
-\code{\link{is.mcmcarray}()},
-\code{\link{is.mcmcr}()}
+Other is:
+\code{\link[=is.mcarray]{is.mcarray()}},
+\code{\link[=is.mcmcarray]{is.mcmcarray()}},
+\code{\link[=is.mcmcr]{is.mcmcr()}}
 }
 \concept{is}

--- a/man/mcmc_aperm.Rd
+++ b/man/mcmc_aperm.Rd
@@ -22,7 +22,7 @@ The modified MCMC object
 Transpose an MCMC object by permuting its parameter dimensions.
 }
 \seealso{
-Other manipulate: 
-\code{\link{mcmc_map}()}
+Other manipulate:
+\code{\link[=mcmc_map]{mcmc_map()}}
 }
 \concept{manipulate}

--- a/man/mcmc_map.Rd
+++ b/man/mcmc_map.Rd
@@ -25,7 +25,7 @@ Adjust the sample values of an MCMC object using a function.
 mcmc_map(mcmcr_example$beta, exp)
 }
 \seealso{
-Other manipulate: 
-\code{\link{mcmc_aperm}()}
+Other manipulate:
+\code{\link[=mcmc_aperm]{mcmc_aperm()}}
 }
 \concept{manipulate}

--- a/man/mcmcarray-object.Rd
+++ b/man/mcmcarray-object.Rd
@@ -15,7 +15,7 @@ ie the chains and iterations, precede the parameter dimensions.
 mcmcr_example$beta
 }
 \seealso{
-Other objects: 
+Other objects:
 \code{\link{mcmcr-object}},
 \code{\link{mcmcrs-object}}
 }

--- a/man/mcmcr-object.Rd
+++ b/man/mcmcr-object.Rd
@@ -16,7 +16,7 @@ to be manipulated and queried as a whole.
 mcmcr_example
 }
 \seealso{
-Other objects: 
+Other objects:
 \code{\link{mcmcarray-object}},
 \code{\link{mcmcrs-object}}
 }

--- a/man/mcmcr-package.Rd
+++ b/man/mcmcr-package.Rd
@@ -22,6 +22,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Joe Thorley \email{joe@poissonconsulting.ca} (\href{https://orcid.org/0000-0002-7683-4592}{ORCID})
 
+Authors:
+\itemize{
+  \item Joe Thorley \email{joe@poissonconsulting.ca} (\href{https://orcid.org/0000-0002-7683-4592}{ORCID})
+}
+
 Other contributors:
 \itemize{
   \item Kirill Müller (\href{https://orcid.org/0000-0002-1416-3412}{ORCID}) [contributor]

--- a/man/mcmcr_example.Rd
+++ b/man/mcmcr_example.Rd
@@ -12,7 +12,7 @@ mcmcr_example
 }
 \description{
 An example \code{\link[=mcmcr-object]{mcmcr-object()}}
-derived from \code{\link[coda:linepost]{coda::line()}}.
+derived from \code{\link[coda:line]{coda::line()}}.
 }
 \examples{
 mcmcr_example

--- a/man/mcmcrs-object.Rd
+++ b/man/mcmcrs-object.Rd
@@ -16,7 +16,7 @@ using the same model to be manipulated and queried as a whole.
 mcmcrs(mcmcr_example, mcmcr_example)
 }
 \seealso{
-Other objects: 
+Other objects:
 \code{\link{mcmcarray-object}},
 \code{\link{mcmcr-object}}
 }

--- a/man/mcmcrs.Rd
+++ b/man/mcmcrs.Rd
@@ -19,9 +19,9 @@ Creates an \code{\link[=mcmcrs-object]{mcmcrs-object()}} from multiple \code{lin
 mcmcrs(mcmcr_example, mcmcr_example)
 }
 \seealso{
-Other coerce: 
-\code{\link{as.mcarray}()},
-\code{\link{as.mcmcarray}()},
-\code{\link{as.mcmcr}()}
+Other coerce:
+\code{\link[=as.mcarray]{as.mcarray()}},
+\code{\link[=as.mcmcarray]{as.mcmcarray()}},
+\code{\link[=as.mcmcr]{as.mcmcr()}}
 }
 \concept{coerce}

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -54,18 +54,18 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{coda}{\code{\link[coda:mcmc]{as.mcmc}}, \code{\link[coda:mcmc.list]{as.mcmc.list}}, \code{\link[coda]{thin}}}
+  \item{coda}{\code{\link[coda:as.mcmc]{as.mcmc()}}, \code{\link[coda:as.mcmc.list]{as.mcmc.list()}}, \code{\link[coda:thin]{thin()}}}
 
-  \item{extras}{\code{\link[extras]{fill_all}}, \code{\link[extras]{fill_na}}, \code{\link[extras]{lower}}, \code{\link[extras]{pvalue}}, \code{\link[extras]{svalue}}, \code{\link[extras]{upper}}, \code{\link[extras]{zscore}}}
+  \item{extras}{\code{\link[extras:fill_all]{fill_all()}}, \code{\link[extras:fill_na]{fill_na()}}, \code{\link[extras:lower]{lower()}}, \code{\link[extras:pvalue]{pvalue()}}, \code{\link[extras:svalue]{svalue()}}, \code{\link[extras:upper]{upper()}}, \code{\link[extras:zscore]{zscore()}}}
 
-  \item{generics}{\code{\link[generics]{tidy}}}
+  \item{generics}{\code{\link[generics:tidy]{tidy()}}}
 
-  \item{nlist}{\code{\link[nlist]{as_nlist}}, \code{\link[nlist]{as_nlists}}, \code{\link[nlist]{nlist}}, \code{\link[nlist]{nlists}}}
+  \item{nlist}{\code{\link[nlist:as_nlist]{as_nlist()}}, \code{\link[nlist:as_nlists]{as_nlists()}}, \code{\link[nlist:nlist]{nlist()}}, \code{\link[nlist:nlists]{nlists()}}}
 
-  \item{stats}{\code{\link[stats]{median}}}
+  \item{stats}{\code{\link[stats:median]{median()}}}
 
-  \item{term}{\code{\link[term]{as_term}}, \code{\link[term:as_term]{as.term}}, \code{\link[term]{complete_terms}}, \code{\link[term:deprecated]{parameters}}, \code{\link[term:deprecated]{parameters<-}}}
+  \item{term}{\code{\link[term:as_term]{as_term()}}, \code{\link[term:as.term]{as.term()}}, \code{\link[term:complete_terms]{complete_terms()}}, \code{\link[term:parameters]{parameters()}}, \code{\link[term:parameters<-]{parameters<-()}}}
 
-  \item{universals}{\code{\link[universals]{bind_chains}}, \code{\link[universals]{bind_iterations}}, \code{\link[universals]{collapse_chains}}, \code{\link[universals]{converged}}, \code{\link[universals]{dims}}, \code{\link[universals]{esr}}, \code{\link[universals]{estimates}}, \code{\link[universals]{nchains}}, \code{\link[universals]{niters}}, \code{\link[universals]{npars}}, \code{\link[universals]{npdims}}, \code{\link[universals]{nterms}}, \code{\link[universals]{pars}}, \code{\link[universals:set_pars]{pars<-}}, \code{\link[universals]{pdims}}, \code{\link[universals]{rhat}}, \code{\link[universals]{set_pars}}, \code{\link[universals]{split_chains}}}
+  \item{universals}{\code{\link[universals:bind_chains]{bind_chains()}}, \code{\link[universals:bind_iterations]{bind_iterations()}}, \code{\link[universals:collapse_chains]{collapse_chains()}}, \code{\link[universals:converged]{converged()}}, \code{\link[universals:dims]{dims()}}, \code{\link[universals:esr]{esr()}}, \code{\link[universals:estimates]{estimates()}}, \code{\link[universals:nchains]{nchains()}}, \code{\link[universals:niters]{niters()}}, \code{\link[universals:npars]{npars()}}, \code{\link[universals:npdims]{npdims()}}, \code{\link[universals:nterms]{nterms()}}, \code{\link[universals:pars]{pars()}}, \code{\link[universals:pars<-]{pars<-()}}, \code{\link[universals:pdims]{pdims()}}, \code{\link[universals:rhat]{rhat()}}, \code{\link[universals:set_pars]{set_pars()}}, \code{\link[universals:split_chains]{split_chains()}}}
 }}
 

--- a/man/vld_mcmcr.Rd
+++ b/man/vld_mcmcr.Rd
@@ -22,7 +22,7 @@ A flag indicating whether the object was validated.
 Validates class and structure of MCMC objects.
 }
 \details{
-To just validate class use \code{\link[chk:chk_s3_class]{chk::vld_s3_class()}}.
+To just validate class use \code{\link[chk:vld_s3_class]{chk::vld_s3_class()}}.
 }
 \section{Functions}{
 \itemize{


### PR DESCRIPTION
The 0.2.1-era soft-deprecations shipped to CRAN in mcmcr 0.3.0 (July 2020) and have been at `deprecate_soft()` for almost six years. This PR escalates them to `deprecate_warn()` so indirect users are also warned:

- `terms()` -> `as_term()`
- `pars(terms = )`
- `check_mcmcarray()` / `check_mcmcr()` -> `chk_mcmcarray()` / `chk_mcmcr()`
- `subset(iterations = )` / `subset(parameters = )` -> `iters` / `pars`
- `zero()` -> `fill_all()`

Also:

- Fixes the nonstandard `"v0.2.1"` `when` strings in `check.R` and `zero.R` so messages read "deprecated in mcmcr 0.2.1" rather than "mcmcr v0.2.1".
- Fixes typos in the `pars(terms = )` deprecation details (wrong package name `terms::` -> `term::`, missing closing backtick, stray `...`).
- Updates the roxygen `@importFrom` from `deprecate_soft` to `deprecate_warn` (no bare `deprecate_soft()` calls remain; the `coef()` and `rhat.mcmcrs()` soft-deprecations are newer and remain unchanged).

Test suite run locally: no new failures (the 7 pre-existing failures on main are chk error-message text changes from the dev version of chk, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)