### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/as-mcmc.list.R
+++ b/R/as-mcmc.list.R
@@ -8,9 +8,13 @@ as.mcmc.list.mcarray <- function(x, ...) as.mcmc.list(as.mcmcarray(x))
 #' @method as.mcmc.list mcmcarray
 #' @export
 as.mcmc.list.mcmcarray <- function(x, ...) {
-  x <- lapply(1:nchains(x), function(chain, x) {
-    subset(x, chains = chain)
-  }, x = x)
+  x <- lapply(
+    1:nchains(x),
+    function(chain, x) {
+      subset(x, chains = chain)
+    },
+    x = x
+  )
   x <- lapply(x, as.mcmc)
   mcmc.list(x)
 }

--- a/R/as-mcmcarray.R
+++ b/R/as-mcmcarray.R
@@ -29,7 +29,9 @@ as.mcmcarray.mcmcarray <- function(x, ...) x
 
 #' @export
 as.mcmcarray.mcmc <- function(x, ...) {
-  if (npars(x) != 1) abort_chk("`x` must only have 1 parameter")
+  if (npars(x) != 1) {
+    abort_chk("`x` must only have 1 parameter")
+  }
 
   x <- complete_terms(x)
   if (nterms(x)) {
@@ -47,6 +49,8 @@ as.mcmcarray.mcmc.list <- function(x, ...) as.mcmcarray(as.mcmcr(x))
 
 #' @export
 as.mcmcarray.mcmcr <- function(x, ...) {
-  if (npars(x) != 1) abort_chk("`x` must only have 1 parameter")
+  if (npars(x) != 1) {
+    abort_chk("`x` must only have 1 parameter")
+  }
   x[[1]]
 }

--- a/R/as-mcmcr.R
+++ b/R/as-mcmcr.R
@@ -91,6 +91,8 @@ as.mcmcr.mcmcr <- function(x, ...) x
 #' @describeIn as.mcmcr Convert tan [mcmcr::mcmcrs-object()] to an mcmcr object
 #' @export
 as.mcmcr.mcmcrs <- function(x, ...) {
-  if (!identical(length(x), 1L)) abort_chk("`x` must have one mcmcr object")
+  if (!identical(length(x), 1L)) {
+    abort_chk("`x` must have one mcmcr object")
+  }
   x[[1]]
 }

--- a/R/as-mcmcrs.R
+++ b/R/as-mcmcrs.R
@@ -41,7 +41,9 @@ as.mcmcrs.list <- function(x, ...) {
 
   if (is.null(names(x))) {
     names(x) <- paste0("mcmcr", 1:length(x))
-  } else if (anyDuplicated(names(x))) abort_chk("mcmcr objects must have unique names")
+  } else if (anyDuplicated(names(x))) {
+    abort_chk("mcmcr objects must have unique names")
+  }
   set_class(x, "mcmcrs")
 }
 

--- a/R/as-term.R
+++ b/R/as-term.R
@@ -30,7 +30,9 @@ as_term.mcmcarray <- function(x, ...) {
 as_term.mcmcr <- function(x, ...) {
   parameters <- names(x)
   x <- lapply(x, as_term)
-  x <- mapply(x, parameters,
+  x <- mapply(
+    x,
+    parameters,
     FUN = function(x, y) {
       sub("parameter", y, x, fixed = TRUE)
     },

--- a/R/bind-dimensions-n.R
+++ b/R/bind-dimensions-n.R
@@ -17,7 +17,9 @@ bind_dimensions_n <- function(...) {
 bind_dimensions_n.mcmcarray <- function(...) {
   x <- list(...)
 
-  if (!length(x)) abort_chk("one or more objects must be passed to bind_dimensions_n")
+  if (!length(x)) {
+    abort_chk("one or more objects must be passed to bind_dimensions_n")
+  }
 
   if (length(x) == 1) {
     return(x[[1]])
@@ -40,7 +42,9 @@ bind_dimensions_n.mcmcarray <- function(...) {
 bind_dimensions_n.mcmcr <- function(...) {
   x <- list(...)
 
-  if (!length(x)) abort_chk("one or more objects must be passed to bind_dimensions_n")
+  if (!length(x)) {
+    abort_chk("one or more objects must be passed to bind_dimensions_n")
+  }
 
   if (length(x) == 1) {
     return(x[[1]])

--- a/R/bind-dimensions.R
+++ b/R/bind-dimensions.R
@@ -18,7 +18,9 @@ bind_dimensions <- function(x, x2, along = NULL, ...) {
 #' @export
 bind_dimensions.mcmcarray <- function(x, x2, along = NULL, ...) {
   chk_s3_class(x2, "mcmcarray")
-  if (!is.null(along)) chk_whole_number(along)
+  if (!is.null(along)) {
+    chk_whole_number(along)
+  }
 
   if (!identical(nchains(x), nchains(x2))) {
     abort_chk("`x` and `x2` must have the same number of chains")
@@ -28,7 +30,9 @@ bind_dimensions.mcmcarray <- function(x, x2, along = NULL, ...) {
     abort_chk("`x` and `x2` must have the same number of iterations")
   }
 
-  if (is.null(along)) along <- max(ndims(x), ndims(x2)) - 1
+  if (is.null(along)) {
+    along <- max(ndims(x), ndims(x2)) - 1
+  }
 
   x <- abind(x, x2, along = along + 2, dimnames = FALSE)
   set_class(x, "mcmcarray")
@@ -58,13 +62,24 @@ bind_dimensions.mcmcr <- function(x, x2, along = NULL, ...) {
   }
 
   if (is.null(along)) {
-    along <- mapply(x, x2, FUN = function(x, x2) {
-      max(ndims(x), ndims(x2)) - 1L
-    }, SIMPLIFY = FALSE)
+    along <- mapply(
+      x,
+      x2,
+      FUN = function(x, x2) {
+        max(ndims(x), ndims(x2)) - 1L
+      },
+      SIMPLIFY = FALSE
+    )
   } else if (length(along) == 1) {
     along <- rep(along, length(x))
   }
 
-  x <- mapply(x = x, x2 = x2, along = along, FUN = bind_dimensions, SIMPLIFY = FALSE)
+  x <- mapply(
+    x = x,
+    x2 = x2,
+    along = along,
+    FUN = bind_dimensions,
+    SIMPLIFY = FALSE
+  )
   set_class(x, "mcmcr")
 }

--- a/R/check.R
+++ b/R/check.R
@@ -16,7 +16,9 @@ check_mcmcarray <- function(x, x_name = substitute(x), error = TRUE) {
   chk_flag(error)
 
   chk_s3_class(x, "mcmcarray", x_name = x_name)
-  if (!is.array(x)) abort_chk(x_name, " must be an array")
+  if (!is.array(x)) {
+    abort_chk(x_name, " must be an array")
+  }
   chk_not_any_na(x, x_name = x_name)
   invisible(x)
 }
@@ -32,7 +34,12 @@ check_mcmcarray <- function(x, x_name = substitute(x), error = TRUE) {
 #'
 #' @examples
 #' check_mcmcr(mcmcr::mcmcr_example)
-check_mcmcr <- function(x, sorted = FALSE, x_name = substitute(x), error = TRUE) {
+check_mcmcr <- function(
+  x,
+  sorted = FALSE,
+  x_name = substitute(x),
+  error = TRUE
+) {
   lifecycle::deprecate_soft("v0.2.1", "check_mcmcr()", "chk_mcmcr()")
   x_name <- deparse_backtick_chk(x_name)
   chk_flag(sorted)
@@ -42,8 +49,12 @@ check_mcmcr <- function(x, sorted = FALSE, x_name = substitute(x), error = TRUE)
   chk_s3_class(x, "mcmcr", x_name = x_name)
   chk_named(x)
   chk_unique(names(x))
-  if (sorted) chk_sorted(names(x), x_name = p0("names of ", x_name))
-  mapply(check_mcmcarray, x,
+  if (sorted) {
+    chk_sorted(names(x), x_name = p0("names of ", x_name))
+  }
+  mapply(
+    check_mcmcarray,
+    x,
     x_name = p0(x_name, " parameter '", pars(x), "'"),
     MoreArgs = list(error = error)
   )

--- a/R/chk.R
+++ b/R/chk.R
@@ -31,7 +31,9 @@ chk_mcmcarray <- function(x, x_name = NULL) {
   if (vld_mcmcarray(x)) {
     return(invisible())
   }
-  if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
+  if (is.null(x_name)) {
+    x_name <- deparse_backtick_chk(substitute(x))
+  }
   chk_s3_class(x, "mcmcarray", x_name = x_name)
   chk_array(x, x_name = x_name)
   chk_numeric(x, x_name = x_name)
@@ -55,7 +57,9 @@ chk_mcmcr <- function(x, x_name = NULL) {
   if (vld_mcmcr(x)) {
     return(invisible())
   }
-  if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
+  if (is.null(x_name)) {
+    x_name <- deparse_backtick_chk(substitute(x))
+  }
   chk_s3_class(x, "mcmcr", x_name = x_name)
   chk_list(x, x_name = x_name)
   chk_named(x, x_name = x_name)
@@ -64,9 +68,19 @@ chk_mcmcr <- function(x, x_name = NULL) {
   }
   chk_all(x, chk_mcmcarray, x_name = x_name)
   if (!vld_all_identical(lapply(x, nchains))) {
-    abort_chk("mcmcarray elements of ", x_name, " must have the same number of chains", tidy = FALSE)
+    abort_chk(
+      "mcmcarray elements of ",
+      x_name,
+      " must have the same number of chains",
+      tidy = FALSE
+    )
   }
-  abort_chk("mcmcarray elements of ", x_name, " must have the same number of iterations", tidy = FALSE)
+  abort_chk(
+    "mcmcarray elements of ",
+    x_name,
+    " must have the same number of iterations",
+    tidy = FALSE
+  )
 }
 
 #' @describeIn chk_mcmcr Check mcmcrs Object
@@ -87,15 +101,32 @@ chk_mcmcrs <- function(x, x_name = NULL) {
   if (vld_mcmcrs(x)) {
     return(invisible())
   }
-  if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
+  if (is.null(x_name)) {
+    x_name <- deparse_backtick_chk(substitute(x))
+  }
   chk_s3_class(x, "mcmcrs", x_name = x_name)
   chk_list(x, x_name = x_name)
   chk_all(x, chk_mcmcr, x_name = x_name)
   if (!vld_all_identical(lapply(x, pars))) {
-    abort_chk("mcmcr elements of ", x_name, " must have the same parameters", tidy = FALSE)
+    abort_chk(
+      "mcmcr elements of ",
+      x_name,
+      " must have the same parameters",
+      tidy = FALSE
+    )
   }
   if (!vld_all_identical(lapply(x, nchains))) {
-    abort_chk("mcmcr elements of ", x_name, " must have the same number of chains", tidy = FALSE)
+    abort_chk(
+      "mcmcr elements of ",
+      x_name,
+      " must have the same number of chains",
+      tidy = FALSE
+    )
   }
-  abort_chk("mcmcr elements of ", x_name, " must have the same number of iterations", tidy = FALSE)
+  abort_chk(
+    "mcmcr elements of ",
+    x_name,
+    " must have the same number of iterations",
+    tidy = FALSE
+  )
 }

--- a/R/coef.R
+++ b/R/coef.R
@@ -14,7 +14,10 @@
 #' @name coef
 NULL
 
-warn_default_directional_information <- function(env = parent.frame(), user_env = parent.frame(2)) {
+warn_default_directional_information <- function(
+  env = parent.frame(),
+  user_env = parent.frame(2)
+) {
   lifecycle::deprecate_soft(
     "0.7.0",
     "coef(directional_information = 'should be explicitly set')",
@@ -28,8 +31,13 @@ warn_default_directional_information <- function(env = parent.frame(), user_env 
 }
 
 # .simplify is a necessary hack to stop apply using simplify argument!
-coef_numeric_impl <- function(object, conf_level, estimate, .simplify,
-                              directional_information) {
+coef_numeric_impl <- function(
+  object,
+  conf_level,
+  estimate,
+  .simplify,
+  directional_information
+) {
   simplify <- .simplify
   chk_number(conf_level)
   chk_range(conf_level)
@@ -44,12 +52,21 @@ coef_numeric_impl <- function(object, conf_level, estimate, .simplify,
   lower <- (1 - conf_level) / 2
   upper <- conf_level + lower
 
-  quantiles <- stats::quantile(object, c(lower, upper), na.rm = TRUE, names = FALSE)
+  quantiles <- stats::quantile(
+    object,
+    c(lower, upper),
+    na.rm = TRUE,
+    names = FALSE
+  )
 
-  if (anyNA(object) || identical(length(object), 1L)) quantiles[c(1, 2)] <- NA
+  if (anyNA(object) || identical(length(object), 1L)) {
+    quantiles[c(1, 2)] <- NA
+  }
 
   estimate <- estimate(object)
-  if (!identical(length(estimate), 1L)) abort_chk("`estimate` must return a scalar")
+  if (!identical(length(estimate), 1L)) {
+    abort_chk("`estimate` must return a scalar")
+  }
 
   if (simplify) {
     svalue <- if (directional_information) {
@@ -58,7 +75,9 @@ coef_numeric_impl <- function(object, conf_level, estimate, .simplify,
       extras::svalue(object)
     }
     return(tibble(
-      estimate = estimate, lower = quantiles[1], upper = quantiles[2],
+      estimate = estimate,
+      lower = quantiles[1],
+      upper = quantiles[2],
       svalue = svalue
     ))
   }
@@ -66,47 +85,78 @@ coef_numeric_impl <- function(object, conf_level, estimate, .simplify,
   zscore <- mean(object) / sd
 
   tibble(
-    estimate = estimate, sd = sd, zscore = zscore,
-    lower = quantiles[1], upper = quantiles[2], pvalue = extras::pvalue(object)
+    estimate = estimate,
+    sd = sd,
+    zscore = zscore,
+    lower = quantiles[1],
+    upper = quantiles[2],
+    pvalue = extras::pvalue(object)
   )
 }
 
 #' @export
-coef.numeric <- function(object, conf_level = 0.95, estimate = median, simplify = TRUE,
-                         directional_information = FALSE, ...) {
+coef.numeric <- function(
+  object,
+  conf_level = 0.95,
+  estimate = median,
+  simplify = TRUE,
+  directional_information = FALSE,
+  ...
+) {
   if (simplify && missing(directional_information)) {
     warn_default_directional_information()
   }
-  coef_numeric_impl(object,
-    conf_level = conf_level, estimate = estimate, .simplify = simplify,
+  coef_numeric_impl(
+    object,
+    conf_level = conf_level,
+    estimate = estimate,
+    .simplify = simplify,
     directional_information = directional_information
   )
 }
 
 #' @export
-coef.mcarray <- function(object, conf_level = 0.95, estimate = median, simplify = TRUE,
-                         directional_information = FALSE, ...) {
+coef.mcarray <- function(
+  object,
+  conf_level = 0.95,
+  estimate = median,
+  simplify = TRUE,
+  directional_information = FALSE,
+  ...
+) {
   if (simplify && missing(directional_information)) {
     warn_default_directional_information()
   }
-  coef(as.mcmc.list(object),
-    conf_level = conf_level, estimate = estimate, simplify = simplify,
+  coef(
+    as.mcmc.list(object),
+    conf_level = conf_level,
+    estimate = estimate,
+    simplify = simplify,
     directional_information = directional_information
   )
 }
 
 #' @describeIn coef Get coefficients for terms in mcmc object
 #' @export
-coef.mcmc <- function(object, conf_level = 0.95, estimate = median, simplify = TRUE,
-                      directional_information = FALSE, ...) {
+coef.mcmc <- function(
+  object,
+  conf_level = 0.95,
+  estimate = median,
+  simplify = TRUE,
+  directional_information = FALSE,
+  ...
+) {
   if (simplify && missing(directional_information)) {
     warn_default_directional_information()
   }
   term <- as_term(object)
   object <- t(object)
-  object <- apply(object,
-    MARGIN = 1, FUN = coef_numeric_impl,
-    conf_level = conf_level, estimate = estimate,
+  object <- apply(
+    object,
+    MARGIN = 1,
+    FUN = coef_numeric_impl,
+    conf_level = conf_level,
+    estimate = estimate,
     .simplify = simplify,
     directional_information = directional_information
   )
@@ -122,38 +172,65 @@ coef.mcmc <- function(object, conf_level = 0.95, estimate = median, simplify = T
 }
 
 #' @export
-coef.mcmc.list <- function(object, conf_level = 0.95, estimate = median, simplify = TRUE,
-                           directional_information = FALSE, ...) {
+coef.mcmc.list <- function(
+  object,
+  conf_level = 0.95,
+  estimate = median,
+  simplify = TRUE,
+  directional_information = FALSE,
+  ...
+) {
   if (simplify && missing(directional_information)) {
     warn_default_directional_information()
   }
   object <- as.mcmc(collapse_chains(object))
-  coef(object,
-    conf_level = conf_level, estimate = estimate, simplify = simplify,
+  coef(
+    object,
+    conf_level = conf_level,
+    estimate = estimate,
+    simplify = simplify,
     directional_information = directional_information
   )
 }
 
 #' @export
-coef.mcmcarray <- function(object, conf_level = 0.95, estimate = median, simplify = TRUE,
-                           directional_information = FALSE, ...) {
+coef.mcmcarray <- function(
+  object,
+  conf_level = 0.95,
+  estimate = median,
+  simplify = TRUE,
+  directional_information = FALSE,
+  ...
+) {
   if (simplify && missing(directional_information)) {
     warn_default_directional_information()
   }
-  coef(as.mcmc.list(object),
-    conf_level = conf_level, estimate = estimate, simplify = simplify,
+  coef(
+    as.mcmc.list(object),
+    conf_level = conf_level,
+    estimate = estimate,
+    simplify = simplify,
     directional_information = directional_information
   )
 }
 
 #' @export
-coef.mcmcr <- function(object, conf_level = 0.95, estimate = median, simplify = TRUE,
-                       directional_information = FALSE, ...) {
+coef.mcmcr <- function(
+  object,
+  conf_level = 0.95,
+  estimate = median,
+  simplify = TRUE,
+  directional_information = FALSE,
+  ...
+) {
   if (simplify && missing(directional_information)) {
     warn_default_directional_information()
   }
-  coef(as.mcmc.list(object),
-    conf_level = conf_level, estimate = estimate, simplify = simplify,
+  coef(
+    as.mcmc.list(object),
+    conf_level = conf_level,
+    estimate = estimate,
+    simplify = simplify,
     directional_information = directional_information
   )
 }

--- a/R/combine-dimensions.R
+++ b/R/combine-dimensions.R
@@ -26,7 +26,9 @@ combine_dimensions.mcmcarray <- function(x, fun = mean, along = NULL, ...) {
   chk_unused(...)
 
   pdims <- pdims(x)
-  if (is.null(along)) along <- length(pdims)
+  if (is.null(along)) {
+    along <- length(pdims)
+  }
 
   n <- 1:length(pdims)
   n <- n[-along]
@@ -40,7 +42,9 @@ combine_dimensions.mcmcarray <- function(x, fun = mean, along = NULL, ...) {
   dim(x) <- dim
   x <- set_class(x, "mcmcarray")
 
-  if (!identical(pdims(x), pdims)) abort_chk("`fun` must return a scalar")
+  if (!identical(pdims(x), pdims)) {
+    abort_chk("`fun` must return a scalar")
+  }
   x
 }
 
@@ -70,7 +74,10 @@ combine_dimensions.mcmcr <- function(x, fun = mean, along = NULL, ...) {
   }
 
   x <- mapply(
-    FUN = combine_dimensions, x = x, along = along, MoreArgs = list(fun = fun),
+    FUN = combine_dimensions,
+    x = x,
+    along = along,
+    MoreArgs = list(fun = fun),
     SIMPLIFY = FALSE
   )
   set_class(x, "mcmcr")

--- a/R/combine-samples.R
+++ b/R/combine-samples.R
@@ -25,7 +25,9 @@ combine_samples.mcmcarray <- function(x, x2, fun = mean, ...) {
   x <- bind_dimensions(x, x2)
   x <- apply(x, (2:ndims(x) - 1L), fun)
 
-  if (!identical(dims(x), dims(x2))) abort_chk("`fun` must return a scalar")
+  if (!identical(dims(x), dims(x2))) {
+    abort_chk("`fun` must return a scalar")
+  }
   set_class(x, "mcmcarray")
 }
 
@@ -40,9 +42,13 @@ combine_samples.mcmcr <- function(x, x2, fun = mean, ...) {
   }
 
   x <- bind_dimensions(x, x2)
-  x <- lapply(x, function(x, fun) {
-    apply(x, (2:ndims(x) - 1L), fun)
-  }, fun = fun)
+  x <- lapply(
+    x,
+    function(x, fun) {
+      apply(x, (2:ndims(x) - 1L), fun)
+    },
+    fun = fun
+  )
   x <- lapply(x, function(x) set_class(x, "mcmcarray"))
   x <- set_class(x, "mcmcr")
 

--- a/R/converged.R
+++ b/R/converged.R
@@ -6,8 +6,15 @@ universals::converged
 #' @export
 #' @examples
 #' converged(mcmcr_example)
-converged.default <- function(x, rhat = 1.1, esr = 0.33, by = "all",
-                              as_df = FALSE, na_rm = FALSE, ...) {
+converged.default <- function(
+  x,
+  rhat = 1.1,
+  esr = 0.33,
+  by = "all",
+  as_df = FALSE,
+  na_rm = FALSE,
+  ...
+) {
   chk_number(rhat)
   chk_range(rhat, c(1, 10))
   chk_number(esr)
@@ -37,13 +44,36 @@ converged.default <- function(x, rhat = 1.1, esr = 0.33, by = "all",
 #' @examples
 #' converged(mcmcrs(mcmcr_example, mcmcr_example))
 #' converged(mcmcrs(mcmcr_example, mcmcr_example), bound = TRUE)
-converged.mcmcrs <- function(x, rhat = 1.1, esr = 0.33, by = "all", as_df = FALSE,
-                             bound = FALSE, na_rm = FALSE, ...) {
+converged.mcmcrs <- function(
+  x,
+  rhat = 1.1,
+  esr = 0.33,
+  by = "all",
+  as_df = FALSE,
+  bound = FALSE,
+  na_rm = FALSE,
+  ...
+) {
   chk_flag(bound)
   chk_unused(...)
   if (bound) {
     x <- Reduce(bind_chains, x)
-    return(converged(x, rhat = rhat, esr = esr, by = by, as_df = as_df, na_rm = na_rm))
+    return(converged(
+      x,
+      rhat = rhat,
+      esr = esr,
+      by = by,
+      as_df = as_df,
+      na_rm = na_rm
+    ))
   }
-  lapply(x, converged, rhat = rhat, esr = esr, by = by, as_df = as_df, na_rm = na_rm)
+  lapply(
+    x,
+    converged,
+    rhat = rhat,
+    esr = esr,
+    by = by,
+    as_df = as_df,
+    na_rm = na_rm
+  )
 }

--- a/R/internal.R
+++ b/R/internal.R
@@ -1,7 +1,9 @@
 subset_mcmcarray_iteration <- function(x, iteration) {
   x <- abind::asub(x, iteration, 2L, drop = FALSE)
   dim <- dim(x)[-c(1, 2)]
-  if (length(dim) == 1) dim <- NULL
+  if (length(dim) == 1) {
+    dim <- NULL
+  }
   dim(x) <- dim
   x
 }
@@ -42,7 +44,12 @@ set_class <- function(x, class) {
   if (length(unique(x)) == 1) {
     return(1)
   }
-  x <- stats::acf(x, lag.max = length(x) - 1, na.action = na.pass, plot = FALSE)$acf[, , 1]
+  x <- stats::acf(
+    x,
+    lag.max = length(x) - 1,
+    na.action = na.pass,
+    plot = FALSE
+  )$acf[,, 1]
 
   if (is.nan(x[1])) {
     return(1)
@@ -58,8 +65,12 @@ set_class <- function(x, class) {
   stopifnot(is.matrix(object))
   nrow <- nrow(object)
   object <- apply(object, 1L, fun, ...)
-  if (!identical(dims(object), nrow)) abort_chk("`fun` must return a scalar")
-  if (!is.numeric(object)) abort_chk("`fun` must return a numeric")
+  if (!identical(dims(object), nrow)) {
+    abort_chk("`fun` must return a scalar")
+  }
+  if (!is.numeric(object)) {
+    abort_chk("`fun` must return a numeric")
+  }
   object
 }
 
@@ -76,7 +87,9 @@ set_class <- function(x, class) {
   var_within <- mean(var_chain)
   rhat <- sqrt((var_between / var_within + niters - 1) / niters)
 
-  if (is.nan(rhat) || (!is.na(rhat) && rhat < 1)) rhat <- 1
+  if (is.nan(rhat) || (!is.na(rhat) && rhat < 1)) {
+    rhat <- 1
+  }
   round(rhat, 3)
 }
 
@@ -88,7 +101,9 @@ tibble <- function(...) {
 
 abind <- function(x, x2, along, dimnames = TRUE) {
   x <- abind::abind(x, x2, along = along)
-  if (!isTRUE(dimnames)) dimnames(x) <- NULL
+  if (!isTRUE(dimnames)) {
+    dimnames(x) <- NULL
+  }
   x
 }
 

--- a/R/mcmc-aperm.R
+++ b/R/mcmc-aperm.R
@@ -23,7 +23,10 @@ mcmc_aperm.mcmcarray <- function(x, perm = NULL, ...) {
   chk_unused(...)
 
   perm_all <- 1:npdims(x)
-  perm <- c(perm, if (!is.null(perm)) setdiff(perm_all, perm) else rev(perm_all))
+  perm <- c(
+    perm,
+    if (!is.null(perm)) setdiff(perm_all, perm) else rev(perm_all)
+  )
   perm <- c(1L, 2L, perm + 2L)
   x <- aperm(x, perm = perm)
   set_class(x, "mcmcarray")

--- a/R/mcmc-map.R
+++ b/R/mcmc-map.R
@@ -26,8 +26,12 @@ mcmc_map.mcmcarray <- function(.x, .f, .by = 1:npdims(.x), ...) {
     chk_sorted(.by)
   }
 
-  if (isTRUE(.by)) .by <- by_all
-  if (isFALSE(.by)) .by <- NULL
+  if (isTRUE(.by)) {
+    .by <- by_all
+  }
+  if (isFALSE(.by)) {
+    .by <- NULL
+  }
 
   x <- apply(.x, MARGIN = c(1L, 2L, .by + 2L), FUN = .f, ...)
 

--- a/R/pars.R
+++ b/R/pars.R
@@ -7,8 +7,9 @@ pars_impl <- function(x, scalar, terms) {
     return(names(x))
   }
   x <- as_term(x)
-  if (isTRUE(terms))
+  if (isTRUE(terms)) {
     return(pars_terms(x))
+  }
 
   pars(as_term_rcrd(x), scalar = scalar)
 }
@@ -17,12 +18,19 @@ pars_impl <- function(x, scalar, terms) {
 #' @inheritParams params
 #' @export
 pars.mcmcr <- function(x, scalar = NULL, terms = FALSE, ...) {
-  if (!is.null(scalar)) chk_flag(scalar)
+  if (!is.null(scalar)) {
+    chk_flag(scalar)
+  }
   chk_flag(terms)
   chk_unused(...)
 
   if (!missing(terms)) {
-    deprecate_soft("0.2.1", "mcmcr::pars(terms =)", details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)...`.", id = "pars_terms")
+    deprecate_soft(
+      "0.2.1",
+      "mcmcr::pars(terms =)",
+      details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)...`.",
+      id = "pars_terms"
+    )
   }
   pars_impl(x, scalar, terms)
 }
@@ -31,12 +39,19 @@ pars.mcmcr <- function(x, scalar = NULL, terms = FALSE, ...) {
 #' @inheritParams params
 #' @export
 pars.mcmcrs <- function(x, scalar = NULL, terms = FALSE, ...) {
-  if (!is.null(scalar)) chk_flag(scalar)
+  if (!is.null(scalar)) {
+    chk_flag(scalar)
+  }
   chk_flag(terms)
   chk_unused(...)
 
   if (!missing(terms)) {
-    deprecate_soft("0.2.1", "mcmcr::pars(terms =)", details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.", id = "pars_terms")
+    deprecate_soft(
+      "0.2.1",
+      "mcmcr::pars(terms =)",
+      details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.",
+      id = "pars_terms"
+    )
   }
   pars_impl(x[[1]], scalar = scalar, terms = terms, ...)
 }

--- a/R/rhat.R
+++ b/R/rhat.R
@@ -104,8 +104,14 @@ rhat.mcmcr <- function(x, by = "all", as_df = FALSE, na_rm = FALSE, ...) {
 #' @examples
 #' rhat(mcmcrs(mcmcr_example, mcmcr_example))
 #' rhat(mcmcrs(mcmcr_example, mcmcr_example), bound = TRUE)
-rhat.mcmcrs <- function(x, by = "all", as_df = FALSE, na_rm = FALSE,
-                        bound = FALSE, ...) {
+rhat.mcmcrs <- function(
+  x,
+  by = "all",
+  as_df = FALSE,
+  na_rm = FALSE,
+  bound = FALSE,
+  ...
+) {
   chk_flag(bound)
   chk_unused(...)
 

--- a/R/sort.R
+++ b/R/sort.R
@@ -2,4 +2,6 @@
 sort.mcmcr <- function(x, ...) subset(x, pars = sort(pars(x)))
 
 #' @export
-sort.mcmcrs <- function(x, ...) set_class(lapply(x[order(names(x))], sort), "mcmcrs")
+sort.mcmcrs <- function(x, ...) {
+  set_class(lapply(x[order(names(x))], sort), "mcmcrs")
+}

--- a/R/split-chains.R
+++ b/R/split-chains.R
@@ -8,7 +8,9 @@ split_chains.mcmcarray <- function(x, ...) {
   niters <- niters(x)
   n <- floor(niters / 2L)
 
-  if (n == 0) abort_chk("`x` must have at least two iterations")
+  if (n == 0) {
+    abort_chk("`x` must have at least two iterations")
+  }
 
   y <- subset(x, iters = (n + 1L):(n * 2L))
   x <- subset(x, iters = 1:n)

--- a/R/subset.R
+++ b/R/subset.R
@@ -16,10 +16,18 @@ NULL
 
 #' @describeIn subset Subset an mcmcarray object
 #' @export
-subset.mcmcarray <- function(x, chains = NULL, iters = NULL,
-                             iterations = NULL, ...) {
+subset.mcmcarray <- function(
+  x,
+  chains = NULL,
+  iters = NULL,
+  iterations = NULL,
+  ...
+) {
   if (!missing(iterations)) {
-    deprecate_soft("0.2.1", "subset(iterations = )", "subset(iters = )",
+    deprecate_soft(
+      "0.2.1",
+      "subset(iterations = )",
+      "subset(iters = )",
       id = "subset_iterations"
     )
     iters <- iterations
@@ -36,24 +44,41 @@ subset.mcmcarray <- function(x, chains = NULL, iters = NULL,
   }
   chk_unused(...)
 
-  if (!is.null(chains)) x <- abind::asub(x, chains, 1L, drop = FALSE)
-  if (!is.null(iters)) x <- abind::asub(x, iters, 2L, drop = FALSE)
+  if (!is.null(chains)) {
+    x <- abind::asub(x, chains, 1L, drop = FALSE)
+  }
+  if (!is.null(iters)) {
+    x <- abind::asub(x, iters, 2L, drop = FALSE)
+  }
   class(x) <- "mcmcarray"
   x
 }
 
 #' @describeIn subset Subset an mcmcr object
 #' @export
-subset.mcmcr <- function(x, chains = NULL, iters = NULL, pars = NULL,
-                         iterations = NULL, parameters = NULL, ...) {
+subset.mcmcr <- function(
+  x,
+  chains = NULL,
+  iters = NULL,
+  pars = NULL,
+  iterations = NULL,
+  parameters = NULL,
+  ...
+) {
   if (!missing(iterations)) {
-    deprecate_soft("0.2.1", "subset(iterations = )", "subset(iters = )",
+    deprecate_soft(
+      "0.2.1",
+      "subset(iterations = )",
+      "subset(iters = )",
       id = "subset_iterations"
     )
     iters <- iterations
   }
   if (!missing(parameters)) {
-    deprecate_soft("0.2.1", "subset(parameters = )", "subset(pars = )",
+    deprecate_soft(
+      "0.2.1",
+      "subset(parameters = )",
+      "subset(pars = )",
       id = "subset_parameters"
     )
     pars <- parameters
@@ -65,7 +90,9 @@ subset.mcmcr <- function(x, chains = NULL, iters = NULL, pars = NULL,
   }
   chk_unused(...)
 
-  if (!is.null(pars)) x <- x[pars]
+  if (!is.null(pars)) {
+    x <- x[pars]
+  }
 
   x <- lapply(x, subset, chains = chains, iters = iters)
   class(x) <- "mcmcr"
@@ -74,16 +101,29 @@ subset.mcmcr <- function(x, chains = NULL, iters = NULL, pars = NULL,
 
 #' @describeIn subset Subset an mcmcrs object
 #' @export
-subset.mcmcrs <- function(x, chains = NULL, iters = NULL, pars = NULL,
-                          iterations = NULL, parameters = NULL, ...) {
+subset.mcmcrs <- function(
+  x,
+  chains = NULL,
+  iters = NULL,
+  pars = NULL,
+  iterations = NULL,
+  parameters = NULL,
+  ...
+) {
   if (!missing(iterations)) {
-    deprecate_soft("0.2.1", "subset(iterations = )", "subset(iters = )",
+    deprecate_soft(
+      "0.2.1",
+      "subset(iterations = )",
+      "subset(iters = )",
       id = "subset_iterations"
     )
     iters <- iterations
   }
   if (!missing(parameters)) {
-    deprecate_soft("0.2.1", "subset(parameters = )", "subset(pars = )",
+    deprecate_soft(
+      "0.2.1",
+      "subset(parameters = )",
+      "subset(pars = )",
       id = "subset_parameters"
     )
     pars <- parameters

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/data-raw/data-raw.R
+++ b/data-raw/data-raw.R
@@ -7,12 +7,27 @@ data(line, package = "coda")
 
 mcmcr_example <- as.mcmcr(line)
 
-stopifnot(all.equal(as.mcmc.list(mcmcr_example), line, check.attributes = FALSE))
+stopifnot(all.equal(
+  as.mcmc.list(mcmcr_example),
+  line,
+  check.attributes = FALSE
+))
 
-mcmcr_example$alpha <- bind_dimensions(mcmcr_example$alpha, mcmcr_example$alpha + 1, along = 1L)
+mcmcr_example$alpha <- bind_dimensions(
+  mcmcr_example$alpha,
+  mcmcr_example$alpha + 1,
+  along = 1L
+)
 
-mcmcr_example$beta <- bind_dimensions(mcmcr_example$beta, mcmcr_example$beta + 1)
-mcmcr_example$beta <- bind_dimensions(mcmcr_example$beta, mcmcr_example$beta + 1, along = 1L)
+mcmcr_example$beta <- bind_dimensions(
+  mcmcr_example$beta,
+  mcmcr_example$beta + 1
+)
+mcmcr_example$beta <- bind_dimensions(
+  mcmcr_example$beta,
+  mcmcr_example$beta + 1,
+  along = 1L
+)
 
 mcmcr_example2 <- mcmcr_example
 mcmcr_example2$alpha <- mcmc_map(mcmcr_example2$alpha, function(x) x + 1.5)
@@ -24,7 +39,10 @@ usethis::use_data(mcmcr_example, overwrite = TRUE)
 
 mcmcr_example2 <- mcmcr_example
 dim(mcmcr_example2$alpha) <- c(dims(mcmcr_example2$alpha), 1L, 1L)
-mcmcr_example2$beta <- bind_dimensions(mcmcr_example2$beta, mcmcr_example2$beta + 1)
+mcmcr_example2$beta <- bind_dimensions(
+  mcmcr_example2$beta,
+  mcmcr_example2$beta + 1
+)
 dim(mcmcr_example2$sigma) <- c(dims(mcmcr_example2$sigma), 1L, 1L)
 
 usethis::use_data(mcmcr_example2, internal = TRUE, overwrite = TRUE)

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -5,9 +5,11 @@ styler::style_pkg(
   filetype = c("R", "Rmd")
 )
 
-lintr::lint_package(linters = linters_with_defaults(
-  line_length_linter = line_length_linter(1000),
-  object_name_linter = object_name_linter(regexes = ".*"))
+lintr::lint_package(
+  linters = linters_with_defaults(
+    line_length_linter = line_length_linter(1000),
+    object_name_linter = object_name_linter(regexes = ".*")
+  )
 )
 
 lintr::lint_package()

--- a/scripts/cubelyr.R
+++ b/scripts/cubelyr.R
@@ -10,14 +10,21 @@ long <-
   unclass() %>%
   enframe(name = "chain") %>%
   mutate(value = map(value, unclass)) %>%
-  mutate(value = map(
-    value, as_tibble,
-    .name_repair = ~ c(
-      "alpha[1]", "alpha[2]",
-      "beta[1,1]", "beta[1,2]", "beta[2,1]", "beta[2,2]",
-      "sigma"
+  mutate(
+    value = map(
+      value,
+      as_tibble,
+      .name_repair = ~ c(
+        "alpha[1]",
+        "alpha[2]",
+        "beta[1,1]",
+        "beta[1,2]",
+        "beta[2,1]",
+        "beta[2,2]",
+        "sigma"
+      )
     )
-  )) %>%
+  ) %>%
   unnest(value) %>%
   group_by(chain) %>%
   mutate(iteration = row_number()) %>%

--- a/tests/testthat/test-aaa-deprecated.R
+++ b/tests/testthat/test-aaa-deprecated.R
@@ -1,19 +1,28 @@
 test_that("check_mcmcarray", {
   rlang::local_options(lifecycle_verbosity = "quiet")
 
-  expect_identical(check_mcmcarray(mcmcr::mcmcr_example$sigma), mcmcr::mcmcr_example$sigma)
-  expect_error(check_mcmcarray(1), "^`1` must inherit from S3 class 'mcmcarray'[.]$",
+  expect_identical(
+    check_mcmcarray(mcmcr::mcmcr_example$sigma),
+    mcmcr::mcmcr_example$sigma
+  )
+  expect_error(
+    check_mcmcarray(1),
+    "^`1` must inherit from S3 class 'mcmcarray'[.]$",
     class = "chk_error"
   )
 
   x <- set_class(1, "mcmcarray")
-  expect_error(check_mcmcarray(x), "^`x` must be an array[.]$",
+  expect_error(
+    check_mcmcarray(x),
+    "^`x` must be an array[.]$",
     class = "chk_error"
   )
 
   sigma <- mcmcr::mcmcr_example$sigma
   is.na(sigma[2, 2, 1]) <- TRUE
-  expect_error(check_mcmcarray(sigma), "^`sigma` must not have any missing values[.]$",
+  expect_error(
+    check_mcmcarray(sigma),
+    "^`sigma` must not have any missing values[.]$",
     class = "chk_error"
   )
 })
@@ -22,18 +31,28 @@ test_that("check_mcmcr", {
   rlang::local_options(lifecycle_verbosity = "quiet")
 
   expect_identical(check_mcmcr(mcmcr::mcmcr_example), mcmcr::mcmcr_example)
-  expect_identical(check_mcmcr(mcmcr::mcmcr_example, sorted = TRUE), mcmcr::mcmcr_example)
-  expect_error(check_mcmcr(1), "^`1` must inherit from S3 class 'mcmcr'[.]$",
+  expect_identical(
+    check_mcmcr(mcmcr::mcmcr_example, sorted = TRUE),
+    mcmcr::mcmcr_example
+  )
+  expect_error(
+    check_mcmcr(1),
+    "^`1` must inherit from S3 class 'mcmcr'[.]$",
     class = "chk_error"
   )
 
   y <- set_class(list(x = 1), "mcmcr")
-  expect_error(check_mcmcr(y),
+  expect_error(
+    check_mcmcr(y),
     "must inherit from S3 class 'mcmcarray'[.]$",
     class = "chk_error"
   )
 
   mcmcr <- mcmcr::mcmcr_example
   is.na(mcmcr$sigma[2, 2, 1]) <- TRUE
-  expect_error(check_mcmcr(mcmcr), "must not have any missing values", class = "chk_error")
+  expect_error(
+    check_mcmcr(mcmcr),
+    "must not have any missing values",
+    class = "chk_error"
+  )
 })

--- a/tests/testthat/test-aaa-zero.R
+++ b/tests/testthat/test-aaa-zero.R
@@ -2,7 +2,11 @@ test_that("zero.mcarray", {
   rlang::local_options(lifecycle_verbosity = "quiet")
 
   mcarray <- as.mcarray(mcmcr_example[[2]])
-  expect_equal(estimates(zero(mcarray)), matrix(0, nrow = 2, ncol = 2), ignore_attr = FALSE)
+  expect_equal(
+    estimates(zero(mcarray)),
+    matrix(0, nrow = 2, ncol = 2),
+    ignore_attr = FALSE
+  )
 })
 
 
@@ -10,7 +14,11 @@ test_that("zero.mcmcarray", {
   rlang::local_options(lifecycle_verbosity = "quiet")
 
   mcmcarray <- mcmcr_example[[2]]
-  expect_equal(estimates(zero(mcmcarray)), matrix(0, nrow = 2, ncol = 2), ignore_attr = FALSE)
+  expect_equal(
+    estimates(zero(mcmcarray)),
+    matrix(0, nrow = 2, ncol = 2),
+    ignore_attr = FALSE
+  )
 })
 
 test_that("zero.mcmcr", {

--- a/tests/testthat/test-as-mcarray.R
+++ b/tests/testthat/test-as-mcarray.R
@@ -6,11 +6,15 @@ test_that("as.mcarray", {
   expect_equal(mcarrays2, mcarrays)
   expect_equal(mcarrays[[1]], as.mcarray(mcarrays[[1]]))
 
-  expect_error(as.mcarray(coda::as.mcmc.list(mcmcr_example)),
+  expect_error(
+    as.mcarray(coda::as.mcmc.list(mcmcr_example)),
     "^`x` must only have 1 parameter[.]$",
     class = "chk_error"
   )
 
   expect_s3_class(as.mcarray(coda::as.mcmc.list(mcmcr_example[[1]])), "mcarray")
-  expect_s3_class(as.mcarray(as.mcarray(coda::as.mcmc.list(mcmcr_example[[1]]))), "mcarray")
+  expect_s3_class(
+    as.mcarray(as.mcarray(coda::as.mcmc.list(mcmcr_example[[1]]))),
+    "mcarray"
+  )
 })

--- a/tests/testthat/test-as-mcmc.R
+++ b/tests/testthat/test-as-mcmc.R
@@ -1,11 +1,14 @@
 test_that("as.mcmc", {
-  expect_error(coda::as.mcmc(mcmcr_example$alpha),
+  expect_error(
+    coda::as.mcmc(mcmcr_example$alpha),
     "^`nchains\\(x\\)` must be identical to 1L\\.",
     class = "chk_error"
   )
 
   expect_s3_class(
-    as.mcmc(as.mcarray(coda::as.mcmc.list(collapse_chains(mcmcr_example[[1]])))),
+    as.mcmc(as.mcarray(coda::as.mcmc.list(collapse_chains(mcmcr_example[[
+      1
+    ]])))),
     "mcmc"
   )
 })

--- a/tests/testthat/test-as-mcmcarray.R
+++ b/tests/testthat/test-as-mcmcarray.R
@@ -1,5 +1,6 @@
 test_that("as.mcmcarray.mcmc with multiple parameters", {
-  expect_error(as.mcmcarray(as.mcmc(subset(mcmcr::mcmcr_example, chains = 1L))),
+  expect_error(
+    as.mcmcarray(as.mcmc(subset(mcmcr::mcmcr_example, chains = 1L))),
     "^`x` must only have 1 parameter[.]$",
     class = "chk_error"
   )
@@ -14,7 +15,10 @@ test_that("as.mcmcarray.mcmc", {
   x <- coda::as.mcmc(mcmcarray)
   expect_identical(as.mcmcarray(x), mcmcarray)
   colnames(x) <- "1"
-  expect_warning(expect_identical(as.mcmcarray(x), structure(numeric(0), .Dim = c(1L, 400L, 0L), class = "mcmcarray")))
+  expect_warning(expect_identical(
+    as.mcmcarray(x),
+    structure(numeric(0), .Dim = c(1L, 400L, 0L), class = "mcmcarray")
+  ))
 })
 
 test_that("as.mcmcarray.mcmc with missing values", {

--- a/tests/testthat/test-as-mcmcr.R
+++ b/tests/testthat/test-as-mcmcr.R
@@ -1,5 +1,8 @@
 test_that("as.mcmcr.list", {
-  expect_identical(as.mcmcr(unclass(mcmcr::mcmcr_example)), mcmcr::mcmcr_example)
+  expect_identical(
+    as.mcmcr(unclass(mcmcr::mcmcr_example)),
+    mcmcr::mcmcr_example
+  )
 })
 
 test_that("as.mcmcr.mcarray", {
@@ -44,5 +47,8 @@ test_that("as.mcmcr.mcmcr", {
 })
 
 test_that("as.mcmcr.mcmcrs", {
-  expect_identical(as.mcmcr(as.mcmcrs(mcmcr::mcmcr_example)), mcmcr::mcmcr_example)
+  expect_identical(
+    as.mcmcr(as.mcmcrs(mcmcr::mcmcr_example)),
+    mcmcr::mcmcr_example
+  )
 })

--- a/tests/testthat/test-as-term.R
+++ b/tests/testthat/test-as-term.R
@@ -1,16 +1,32 @@
 test_that("as_term", {
   term <- as_term(mcmcr_example)
-  expect_identical(term, term::new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "beta[2,2]", "sigma"
-  )))
+  expect_identical(
+    term,
+    term::new_term(c(
+      "alpha[1]",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
+    ))
+  )
 })
 
 test_that("as.term", {
   rlang::local_options(lifecycle_verbosity = "quiet")
   term <- as_term(mcmcr_example)
-  expect_identical(term, term::new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "beta[2,2]", "sigma"
-  )))
+  expect_identical(
+    term,
+    term::new_term(c(
+      "alpha[1]",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
+    ))
+  )
 })

--- a/tests/testthat/test-bind-chains.R
+++ b/tests/testthat/test-bind-chains.R
@@ -1,17 +1,30 @@
 test_that("bind_chains", {
-  expect_identical(nchains(bind_chains(as.mcmc.list(mcmcr_example), as.mcmc.list(mcmcr_example))), 4L)
-  expect_identical(nchains(bind_chains(mcmcr_example$beta, mcmcr_example$beta)), 4L)
+  expect_identical(
+    nchains(bind_chains(
+      as.mcmc.list(mcmcr_example),
+      as.mcmc.list(mcmcr_example)
+    )),
+    4L
+  )
+  expect_identical(
+    nchains(bind_chains(mcmcr_example$beta, mcmcr_example$beta)),
+    4L
+  )
   expect_identical(nchains(bind_chains(mcmcr_example, mcmcr_example)), 4L)
   expect_identical(nchains(bind_chains(mcmcr_example2, mcmcr_example2)), 4L)
 })
 
 test_that("bind_chains.mcarray", {
-  expect_identical(nchains(bind_chains(
-    as.mcarray(mcmcr_example$beta),
-    as.mcarray(mcmcr_example$beta)
-  )), 4L)
+  expect_identical(
+    nchains(bind_chains(
+      as.mcarray(mcmcr_example$beta),
+      as.mcarray(mcmcr_example$beta)
+    )),
+    4L
+  )
 
-  expect_error(bind_chains(as.mcarray(mcmcr_example$beta), mcmcr_example),
+  expect_error(
+    bind_chains(as.mcarray(mcmcr_example$beta), mcmcr_example),
     "^`x2` must inherit from S3 class 'mcarray'[.]$",
     class = "chk_error"
   )
@@ -27,15 +40,22 @@ test_that("bind_chains.mcarray", {
 })
 
 test_that("bind_chains.mcmc", {
-  expect_identical(nchains(bind_chains(
-    as.mcmc(collapse_chains(mcmcr_example)),
-    as.mcmc(collapse_chains(mcmcr_example))
-  )), 2L)
+  expect_identical(
+    nchains(bind_chains(
+      as.mcmc(collapse_chains(mcmcr_example)),
+      as.mcmc(collapse_chains(mcmcr_example))
+    )),
+    2L
+  )
 
-  expect_error(nchains(bind_chains(
-    as.mcmc(collapse_chains(mcmcr_example)),
-    mcmcr_example
-  )), "^`x2` must inherit from S3 class 'mcmc'[.]$", class = "chk_error")
+  expect_error(
+    nchains(bind_chains(
+      as.mcmc(collapse_chains(mcmcr_example)),
+      mcmcr_example
+    )),
+    "^`x2` must inherit from S3 class 'mcmc'[.]$",
+    class = "chk_error"
+  )
 
   expect_error(
     bind_chains(
@@ -45,7 +65,6 @@ test_that("bind_chains.mcmc", {
     "^`x` and `x2` must have the same parameters[.]$",
     class = "chk_error"
   )
-
 
   expect_error(
     bind_chains(

--- a/tests/testthat/test-bind-dimensions-n.R
+++ b/tests/testthat/test-bind-dimensions-n.R
@@ -1,7 +1,11 @@
 test_that("bind_dimensions_n.mcmcarray", {
   expect_identical(bind_dimensions_n(mcmcr_example$beta), mcmcr_example$beta)
   expect_identical(
-    pdims(bind_dimensions_n(mcmcr_example$beta, mcmcr_example$beta, mcmcr_example$beta)),
+    pdims(bind_dimensions_n(
+      mcmcr_example$beta,
+      mcmcr_example$beta,
+      mcmcr_example$beta
+    )),
     c(2L, 2L, 3L)
   )
 })

--- a/tests/testthat/test-bind-dimensions.R
+++ b/tests/testthat/test-bind-dimensions.R
@@ -1,5 +1,8 @@
 test_that("bind_dimensions", {
-  expect_identical(pdims(bind_dimensions(mcmcr_example$beta, mcmcr_example$beta)), c(2L, 2L, 2L))
+  expect_identical(
+    pdims(bind_dimensions(mcmcr_example$beta, mcmcr_example$beta)),
+    c(2L, 2L, 2L)
+  )
   expect_identical(
     pdims(bind_dimensions(mcmcr_example, mcmcr_example)),
     list(alpha = c(2L, 2L), beta = c(2L, 2L, 2L), sigma = c(1L, 2L))
@@ -12,6 +15,10 @@ test_that("bind_dimensions", {
 
   expect_identical(
     pdims(bind_dimensions(mcmcr_example2, mcmcr_example2)),
-    list(alpha = c(2L, 1L, 1L, 2L), beta = c(2L, 2L, 2L, 2L), sigma = c(1L, 1L, 1L, 2L))
+    list(
+      alpha = c(2L, 1L, 1L, 2L),
+      beta = c(2L, 2L, 2L, 2L),
+      sigma = c(1L, 1L, 1L, 2L)
+    )
   )
 })

--- a/tests/testthat/test-bind-iterations.R
+++ b/tests/testthat/test-bind-iterations.R
@@ -1,7 +1,25 @@
 test_that("bind_iterations", {
-  expect_identical(niters(bind_iterations(as.mcarray(mcmcr_example$beta), as.mcarray(mcmcr_example$beta))), 800L)
-  expect_identical(niters(bind_iterations(as.mcmc.list(mcmcr_example), as.mcmc.list(mcmcr_example))), 800L)
-  expect_identical(niters(bind_iterations(mcmcr_example$beta, mcmcr_example$beta)), 800L)
+  expect_identical(
+    niters(bind_iterations(
+      as.mcarray(mcmcr_example$beta),
+      as.mcarray(mcmcr_example$beta)
+    )),
+    800L
+  )
+  expect_identical(
+    niters(bind_iterations(
+      as.mcmc.list(mcmcr_example),
+      as.mcmc.list(mcmcr_example)
+    )),
+    800L
+  )
+  expect_identical(
+    niters(bind_iterations(mcmcr_example$beta, mcmcr_example$beta)),
+    800L
+  )
   expect_identical(niters(bind_iterations(mcmcr_example, mcmcr_example)), 800L)
-  expect_identical(niters(bind_iterations(mcmcr_example2, mcmcr_example2)), 800L)
+  expect_identical(
+    niters(bind_iterations(mcmcr_example2, mcmcr_example2)),
+    800L
+  )
 })

--- a/tests/testthat/test-bind-parameters.R
+++ b/tests/testthat/test-bind-parameters.R
@@ -1,5 +1,23 @@
 test_that("bind_parameters", {
-  expect_identical(pars(bind_parameters(subset(as.mcmc.list(mcmcr_example), pars = "beta"), subset(as.mcmc.list(mcmcr_example), pars = "alpha"))), c("alpha", "beta"))
-  expect_identical(pars(bind_parameters(subset(mcmcr_example, pars = "beta"), subset(mcmcr_example, pars = "alpha"))), c("alpha", "beta"))
-  expect_identical(pars(bind_parameters(subset(mcmcr_example2, pars = "beta"), subset(mcmcr_example2, pars = "alpha"))), c("alpha", "beta"))
+  expect_identical(
+    pars(bind_parameters(
+      subset(as.mcmc.list(mcmcr_example), pars = "beta"),
+      subset(as.mcmc.list(mcmcr_example), pars = "alpha")
+    )),
+    c("alpha", "beta")
+  )
+  expect_identical(
+    pars(bind_parameters(
+      subset(mcmcr_example, pars = "beta"),
+      subset(mcmcr_example, pars = "alpha")
+    )),
+    c("alpha", "beta")
+  )
+  expect_identical(
+    pars(bind_parameters(
+      subset(mcmcr_example2, pars = "beta"),
+      subset(mcmcr_example2, pars = "alpha")
+    )),
+    c("alpha", "beta")
+  )
 })

--- a/tests/testthat/test-chk.R
+++ b/tests/testthat/test-chk.R
@@ -1,17 +1,23 @@
 test_that("chk_mcmcarray", {
   expect_null(chk_mcmcarray(as.mcmcarray(1)))
   expect_invisible(chk_mcmcarray(as.mcmcarray(1)))
-  expect_error(chk_mcmcarray(1), "^`1` must inherit from S3 class 'mcmcarray'[.]$",
+  expect_error(
+    chk_mcmcarray(1),
+    "^`1` must inherit from S3 class 'mcmcarray'[.]$",
     class = "chk_error"
   )
   x <- 1
   class(x) <- "mcmcarray"
-  expect_error(chk_mcmcarray(x), "^`x` must be an array[.]$",
+  expect_error(
+    chk_mcmcarray(x),
+    "^`x` must be an array[.]$",
     class = "chk_error"
   )
   x <- array(TRUE)
   class(x) <- "mcmcarray"
-  expect_error(chk_mcmcarray(x), "^`x` must be numeric[.]$",
+  expect_error(
+    chk_mcmcarray(x),
+    "^`x` must be numeric[.]$",
     class = "chk_error"
   )
 })
@@ -19,13 +25,16 @@ test_that("chk_mcmcarray", {
 test_that("chk_mcmcr", {
   expect_null(chk_mcmcr(as.mcmcr(list(x = 1))))
   expect_invisible(chk_mcmcr(as.mcmcr(list(x = 1))))
-  expect_error(chk_mcmcr(1), "^`1` must inherit from S3 class 'mcmcr'[.]$",
+  expect_error(
+    chk_mcmcr(1),
+    "^`1` must inherit from S3 class 'mcmcr'[.]$",
     class = "chk_error"
   )
   x <- list(x = 1)
   class(x) <- "mcmcr"
 
-  expect_error(chk_mcmcr(x),
+  expect_error(
+    chk_mcmcr(x),
     "^All elements of `x` must inherit from S3 class 'mcmcarray'[.]$",
     class = "chk_error"
   )
@@ -34,13 +43,16 @@ test_that("chk_mcmcr", {
 test_that("chk_mcmcrs", {
   expect_null(chk_mcmcrs(as.mcmcrs(mcmcr_example)))
   expect_invisible(chk_mcmcr(as.mcmcr(list(x = 1))))
-  expect_error(chk_mcmcr(1), "^`1` must inherit from S3 class 'mcmcr'[.]$",
+  expect_error(
+    chk_mcmcr(1),
+    "^`1` must inherit from S3 class 'mcmcr'[.]$",
     class = "chk_error"
   )
   x <- list(x = 1)
   class(x) <- "mcmcr"
 
-  expect_error(chk_mcmcr(x),
+  expect_error(
+    chk_mcmcr(x),
     "^All elements of `x` must inherit from S3 class 'mcmcarray'[.]$",
     class = "chk_error"
   )

--- a/tests/testthat/test-coef.R
+++ b/tests/testthat/test-coef.R
@@ -2,33 +2,84 @@ test_that("coef.mcmc", {
   rlang::local_options(lifecycle_verbosity = "quiet")
 
   coef_mcmc.list <- coef(as.mcmc.list(mcmcr_example), simplify = FALSE)
-  expect_identical(colnames(coef_mcmc.list), c("term", "estimate", "sd", "zscore", "lower", "upper", "pvalue"))
-  expect_identical(coef_mcmc.list$term, sort(as_term(c("alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]", "beta[1,2]", "beta[2,2]", "sigma"))))
+  expect_identical(
+    colnames(coef_mcmc.list),
+    c("term", "estimate", "sd", "zscore", "lower", "upper", "pvalue")
+  )
+  expect_identical(
+    coef_mcmc.list$term,
+    sort(as_term(c(
+      "alpha[1]",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
+    )))
+  )
 })
 
 test_that("coef.mcmc simplify = TRUE", {
-  coef_mcmc.list <- coef(as.mcmc.list(mcmcr_example), directional_information = FALSE)
-  expect_identical(colnames(coef_mcmc.list), c("term", "estimate", "lower", "upper", "svalue"))
-  expect_identical(coef_mcmc.list$term, sort(as_term(c("alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]", "beta[1,2]", "beta[2,2]", "sigma"))))
+  coef_mcmc.list <- coef(
+    as.mcmc.list(mcmcr_example),
+    directional_information = FALSE
+  )
+  expect_identical(
+    colnames(coef_mcmc.list),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    coef_mcmc.list$term,
+    sort(as_term(c(
+      "alpha[1]",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
+    )))
+  )
 
   coef_mcmcr <- coef(mcmcr_example, directional_information = FALSE)
   expect_identical(coef_mcmcr, coef_mcmc.list)
 
   coef_mcmcr2 <- coef(mcmcr_example2, directional_information = FALSE)
-  expect_identical(colnames(coef_mcmcr2), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef_mcmcr2),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
   expect_identical(nrow(coef_mcmcr2), 11L)
 
   coef_mcmcarray <- coef(mcmcr_example$beta, directional_information = FALSE)
-  expect_identical(colnames(coef_mcmc.list), c("term", "estimate", "lower", "upper", "svalue"))
-  expect_identical(coef_mcmcarray$term, sort(as_term(c("parameter[1,1]", "parameter[2,1]", "parameter[1,2]", "parameter[2,2]"))))
+  expect_identical(
+    colnames(coef_mcmc.list),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    coef_mcmcarray$term,
+    sort(as_term(c(
+      "parameter[1,1]",
+      "parameter[2,1]",
+      "parameter[1,2]",
+      "parameter[2,2]"
+    )))
+  )
 
-  coef_mcarray <- coef(as.mcarray(mcmcr_example$beta), directional_information = FALSE)
+  coef_mcarray <- coef(
+    as.mcarray(mcmcr_example$beta),
+    directional_information = FALSE
+  )
   expect_identical(coef_mcarray, coef_mcmcarray)
 })
 
 test_that("coef directional_information = TRUE", {
   coef_di <- coef(mcmcr_example, directional_information = TRUE)
-  expect_identical(colnames(coef_di), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef_di),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
   coef_svalue <- coef(mcmcr_example, directional_information = FALSE)
   expect_identical(
@@ -88,13 +139,22 @@ test_that("coef directional_information values", {
   expect_identical(coef(-x, directional_information = TRUE)$svalue, 100)
 
   # equal numbers of values on each side: no directional information
-  expect_identical(coef(c(-2, -1, 1, 2), directional_information = TRUE)$svalue, 0)
+  expect_identical(
+    coef(c(-2, -1, 1, 2), directional_information = TRUE)$svalue,
+    0
+  )
 
   # 3:1 split: log2(3/4) - log2(1/4) = log2(3) bits
-  expect_equal(coef(c(-1, 1, 2, 3), directional_information = TRUE)$svalue, log2(3))
+  expect_equal(
+    coef(c(-1, 1, 2, 3), directional_information = TRUE)$svalue,
+    log2(3)
+  )
 
   # missing values propagate
-  expect_identical(coef(c(1, NA), directional_information = TRUE)$svalue, NA_real_)
+  expect_identical(
+    coef(c(1, NA), directional_information = TRUE)$svalue,
+    NA_real_
+  )
 })
 
 test_that("coef soft-deprecates unset directional_information", {

--- a/tests/testthat/test-combine-dimensions.R
+++ b/tests/testthat/test-combine-dimensions.R
@@ -1,20 +1,51 @@
 test_that("combine_dimensions.mcmcarray", {
   expect_identical(pdims(combine_dimensions(mcmcr_example$beta)), c(2L))
-  expect_identical(pdims(combine_dimensions(mcmcr_example$beta, along = 1L)), c(2L))
-  expect_error(combine_dimensions(mcmcr_example$beta, along = 0L), "^`along` must be between 1 and 2, not 0[.]$", class = "chk_error")
-  expect_error(combine_dimensions(mcmcr_example$beta, along = 3L), "^`along` must be between 1 and 2, not 3[.]$", class = "chk_error")
+  expect_identical(
+    pdims(combine_dimensions(mcmcr_example$beta, along = 1L)),
+    c(2L)
+  )
+  expect_error(
+    combine_dimensions(mcmcr_example$beta, along = 0L),
+    "^`along` must be between 1 and 2, not 0[.]$",
+    class = "chk_error"
+  )
+  expect_error(
+    combine_dimensions(mcmcr_example$beta, along = 3L),
+    "^`along` must be between 1 and 2, not 3[.]$",
+    class = "chk_error"
+  )
   expect_identical(pdims(combine_dimensions(mcmcr_example$alpha)), 1L)
   expect_identical(pdims(combine_dimensions(mcmcr_example$sigma)), 1L)
-  expect_identical(pdims(combine_dimensions(mcmcr_example2$sigma, along = 1L)), c(1L, 1L))
-  expect_equal(combine_dimensions(bind_dimensions(mcmcr_example2$beta, mcmcr_example2$beta)), mcmcr_example2$beta, ignore_attr = FALSE)
+  expect_identical(
+    pdims(combine_dimensions(mcmcr_example2$sigma, along = 1L)),
+    c(1L, 1L)
+  )
+  expect_equal(
+    combine_dimensions(bind_dimensions(
+      mcmcr_example2$beta,
+      mcmcr_example2$beta
+    )),
+    mcmcr_example2$beta,
+    ignore_attr = FALSE
+  )
 })
 
 test_that("combine_dimensions.mcmcr", {
-  expect_equal(combine_dimensions(bind_dimensions_n(mcmcr_example, mcmcr_example, mcmcr_example)),
+  expect_equal(
+    combine_dimensions(bind_dimensions_n(
+      mcmcr_example,
+      mcmcr_example,
+      mcmcr_example
+    )),
     mcmcr_example,
     ignore_attr = FALSE
   )
-  expect_equal(combine_dimensions(bind_dimensions_n(mcmcr_example2, mcmcr_example2, mcmcr_example2)),
+  expect_equal(
+    combine_dimensions(bind_dimensions_n(
+      mcmcr_example2,
+      mcmcr_example2,
+      mcmcr_example2
+    )),
     mcmcr_example2,
     ignore_attr = FALSE
   )

--- a/tests/testthat/test-combine-samples-n.R
+++ b/tests/testthat/test-combine-samples-n.R
@@ -1,23 +1,66 @@
 test_that("combine_samples_n.mcmcarray", {
   expect_identical(combine_samples_n(mcmcr_example$beta), mcmcr_example$beta)
 
-  expect_equal(combine_samples_n(list(mcmcr_example$beta, mcmcr_example$beta, mcmcr_example$beta)), mcmcr_example$beta, ignore_attr = FALSE)
+  expect_equal(
+    combine_samples_n(list(
+      mcmcr_example$beta,
+      mcmcr_example$beta,
+      mcmcr_example$beta
+    )),
+    mcmcr_example$beta,
+    ignore_attr = FALSE
+  )
 
-  expect_equal(combine_samples_n(list(mcmcr_example$beta, mcmcr_example$beta, mcmcr_example$beta), mcmcr_example$beta), mcmcr_example$beta, ignore_attr = FALSE)
+  expect_equal(
+    combine_samples_n(
+      list(mcmcr_example$beta, mcmcr_example$beta, mcmcr_example$beta),
+      mcmcr_example$beta
+    ),
+    mcmcr_example$beta,
+    ignore_attr = FALSE
+  )
 
-  expect_equal(combine_samples_n(mcmcr_example$beta, mcmcr_example$beta, mcmcr_example$beta), mcmcr_example$beta, ignore_attr = FALSE)
-  x <- combine_samples_n(mcmcr_example$beta, mcmcr_example$beta, mcmcr_example$beta, fun = sum)
+  expect_equal(
+    combine_samples_n(
+      mcmcr_example$beta,
+      mcmcr_example$beta,
+      mcmcr_example$beta
+    ),
+    mcmcr_example$beta,
+    ignore_attr = FALSE
+  )
+  x <- combine_samples_n(
+    mcmcr_example$beta,
+    mcmcr_example$beta,
+    mcmcr_example$beta,
+    fun = sum
+  )
   expect_equal(x[1, , , ], mcmcr_example$beta[1, , , ] * 3)
 })
 
 test_that("combine_samples_n.mcmcr", {
   expect_identical(combine_samples_n(mcmcr_example), mcmcr_example)
 
-  expect_equal(combine_samples_n(list(mcmcr_example, mcmcr_example, mcmcr_example)), mcmcr_example, ignore_attr = FALSE)
+  expect_equal(
+    combine_samples_n(list(mcmcr_example, mcmcr_example, mcmcr_example)),
+    mcmcr_example,
+    ignore_attr = FALSE
+  )
 
-  expect_equal(combine_samples_n(list(mcmcr_example, mcmcr_example, mcmcr_example), mcmcr_example), mcmcr_example, ignore_attr = FALSE)
+  expect_equal(
+    combine_samples_n(
+      list(mcmcr_example, mcmcr_example, mcmcr_example),
+      mcmcr_example
+    ),
+    mcmcr_example,
+    ignore_attr = FALSE
+  )
 
-  expect_equal(combine_samples_n(mcmcr_example, mcmcr_example, mcmcr_example), mcmcr_example, ignore_attr = FALSE)
+  expect_equal(
+    combine_samples_n(mcmcr_example, mcmcr_example, mcmcr_example),
+    mcmcr_example,
+    ignore_attr = FALSE
+  )
   x <- combine_samples_n(mcmcr_example, mcmcr_example, mcmcr_example, fun = sum)
   expect_equal(x$beta[1, , , ], mcmcr_example$beta[1, , , ] * 3)
 })

--- a/tests/testthat/test-converged.R
+++ b/tests/testthat/test-converged.R
@@ -12,17 +12,23 @@ test_that("converged.mcmcr", {
     converged(mcmcr_example, by = "term"),
     list(
       alpha = c(FALSE, FALSE),
-      beta = structure(c(
-        FALSE, FALSE,
-        FALSE, FALSE
-      ), .Dim = c(2L, 2L)),
+      beta = structure(
+        c(
+          FALSE,
+          FALSE,
+          FALSE,
+          FALSE
+        ),
+        .Dim = c(2L, 2L)
+      ),
       sigma = TRUE
     )
   )
 
   expect_identical(
     converged(mcmcr_example, as_df = TRUE),
-    structure(list(all = "all", converged = FALSE),
+    structure(
+      list(all = "all", converged = FALSE),
       row.names = c(NA, -1L),
       class = c("tbl_df", "tbl", "data.frame")
     )

--- a/tests/testthat/test-esr.R
+++ b/tests/testthat/test-esr.R
@@ -29,49 +29,175 @@ test_that("esr.matrix", {
 
 test_that("esr.mcmcmarray", {
   expect_identical(esr(mcmcr_example[[1]], by = "term"), c(0.011, 0.011))
-  expect_equal(esr(mcmcr_example[[2]], by = "term"), matrix(c(0.05, 0.05, 0.05, 0.05), nrow = 2, ncol = 2))
-  expect_identical(esr(mcmcr_example[[2]], by = "term", as_df = TRUE), tibble(term = as_term(c("parameter[1,1]", "parameter[2,1]", "parameter[1,2]", "parameter[2,2]")), esr = rep(0.05, 4)))
+  expect_equal(
+    esr(mcmcr_example[[2]], by = "term"),
+    matrix(c(0.05, 0.05, 0.05, 0.05), nrow = 2, ncol = 2)
+  )
+  expect_identical(
+    esr(mcmcr_example[[2]], by = "term", as_df = TRUE),
+    tibble(
+      term = as_term(c(
+        "parameter[1,1]",
+        "parameter[2,1]",
+        "parameter[1,2]",
+        "parameter[2,2]"
+      )),
+      esr = rep(0.05, 4)
+    )
+  )
   expect_identical(esr(mcmcr_example[[3]], by = "term"), c(0.472))
-  expect_identical(esr(mcmcr_example[[3]], by = "term", as_df = TRUE), tibble(term = as_term("parameter"), esr = 0.472))
+  expect_identical(
+    esr(mcmcr_example[[3]], by = "term", as_df = TRUE),
+    tibble(term = as_term("parameter"), esr = 0.472)
+  )
   expect_identical(esr(mcmcr_example[[2]]), 0.05)
-  expect_identical(esr(mcmcr_example[[2]], "parameter"), esr(mcmcr_example[[2]], "all"))
-  expect_identical(esr(subset(mcmcr_example[[2]], iters = 1L), by = "term", as_df = TRUE), tibble(term = as_term(c("parameter[1,1]", "parameter[2,1]", "parameter[1,2]", "parameter[2,2]")), esr = rep(1, 4)))
+  expect_identical(
+    esr(mcmcr_example[[2]], "parameter"),
+    esr(mcmcr_example[[2]], "all")
+  )
+  expect_identical(
+    esr(subset(mcmcr_example[[2]], iters = 1L), by = "term", as_df = TRUE),
+    tibble(
+      term = as_term(c(
+        "parameter[1,1]",
+        "parameter[2,1]",
+        "parameter[1,2]",
+        "parameter[2,2]"
+      )),
+      esr = rep(1, 4)
+    )
+  )
 })
 
 test_that("esr.mcarray", {
   mcarray <- as.mcarray(mcmcr::mcmcr_example[[2]])
   expect_identical(esr(mcarray), 0.05)
-  expect_identical(esr(mcarray, as_df = TRUE), tibble(parameter = "parameter", esr = 0.05))
+  expect_identical(
+    esr(mcarray, as_df = TRUE),
+    tibble(parameter = "parameter", esr = 0.05)
+  )
   expect_identical(esr(mcarray, by = "parameter"), 0.05)
-  expect_equal(esr(mcarray, by = "term"), matrix(c(0.05, 0.05, 0.05, 0.05), nrow = 2))
-  expect_equal(esr(mcarray, by = "term", as_df = TRUE), tibble(term = as_term(c("parameter[1,1]", "parameter[2,1]", "parameter[1,2]", "parameter[2,2]")), esr = c(0.05, 0.05, 0.05, 0.05)))
+  expect_equal(
+    esr(mcarray, by = "term"),
+    matrix(c(0.05, 0.05, 0.05, 0.05), nrow = 2)
+  )
+  expect_equal(
+    esr(mcarray, by = "term", as_df = TRUE),
+    tibble(
+      term = as_term(c(
+        "parameter[1,1]",
+        "parameter[2,1]",
+        "parameter[1,2]",
+        "parameter[2,2]"
+      )),
+      esr = c(0.05, 0.05, 0.05, 0.05)
+    )
+  )
 })
 
 test_that("esr.mcmc", {
   mcmc <- as.mcmc(subset(mcmcr::mcmcr_example, chains = 2L))
   expect_identical(esr(mcmc), 0.01)
   expect_identical(esr(mcmc, as_df = TRUE), tibble(all = "all", esr = 0.01))
-  expect_identical(esr(mcmc, by = "parameter"), list(alpha = 0.01, beta = 0.062, sigma = 0.474))
-  expect_equal(esr(mcmc, by = "term"), list(alpha = c(0.01, 0.01), beta = matrix(c(0.062, 0.062, 0.062, 0.062), nrow = 2, ncol = 2), sigma = 0.474))
-  expect_equal(esr(mcmc, by = "term", as_df = TRUE), tibble(term = as_term(c("alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]", "beta[1,2]", "beta[2,2]", "sigma")), esr = c(0.01, 0.01, 0.062, 0.062, 0.062, 0.062, 0.474)))
+  expect_identical(
+    esr(mcmc, by = "parameter"),
+    list(alpha = 0.01, beta = 0.062, sigma = 0.474)
+  )
+  expect_equal(
+    esr(mcmc, by = "term"),
+    list(
+      alpha = c(0.01, 0.01),
+      beta = matrix(c(0.062, 0.062, 0.062, 0.062), nrow = 2, ncol = 2),
+      sigma = 0.474
+    )
+  )
+  expect_equal(
+    esr(mcmc, by = "term", as_df = TRUE),
+    tibble(
+      term = as_term(c(
+        "alpha[1]",
+        "alpha[2]",
+        "beta[1,1]",
+        "beta[2,1]",
+        "beta[1,2]",
+        "beta[2,2]",
+        "sigma"
+      )),
+      esr = c(0.01, 0.01, 0.062, 0.062, 0.062, 0.062, 0.474)
+    )
+  )
 })
 
 test_that("esr.mcmc.list", {
   expect_identical(esr(as.mcmc.list(mcmcr::mcmcr_example)), 0.011)
-  expect_identical(esr(as.mcmc.list(mcmcr::mcmcr_example), as_df = TRUE), tibble(all = "all", esr = 0.011))
-  expect_identical(esr(as.mcmc.list(mcmcr::mcmcr_example), by = "parameter"), list(alpha = 0.011, beta = 0.05, sigma = 0.472))
-  expect_equal(esr(as.mcmc.list(mcmcr::mcmcr_example), by = "term"), list(alpha = c(0.011, 0.011), beta = matrix(c(0.05, 0.05, 0.05, 0.05), nrow = 2, ncol = 2), sigma = 0.472))
-  expect_equal(esr(as.mcmc.list(mcmcr::mcmcr_example), by = "term", as_df = TRUE), tibble(term = as_term(c("alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]", "beta[1,2]", "beta[2,2]", "sigma")), esr = c(0.011, 0.011, 0.05, 0.05, 0.05, 0.05, 0.472)))
+  expect_identical(
+    esr(as.mcmc.list(mcmcr::mcmcr_example), as_df = TRUE),
+    tibble(all = "all", esr = 0.011)
+  )
+  expect_identical(
+    esr(as.mcmc.list(mcmcr::mcmcr_example), by = "parameter"),
+    list(alpha = 0.011, beta = 0.05, sigma = 0.472)
+  )
+  expect_equal(
+    esr(as.mcmc.list(mcmcr::mcmcr_example), by = "term"),
+    list(
+      alpha = c(0.011, 0.011),
+      beta = matrix(c(0.05, 0.05, 0.05, 0.05), nrow = 2, ncol = 2),
+      sigma = 0.472
+    )
+  )
+  expect_equal(
+    esr(as.mcmc.list(mcmcr::mcmcr_example), by = "term", as_df = TRUE),
+    tibble(
+      term = as_term(c(
+        "alpha[1]",
+        "alpha[2]",
+        "beta[1,1]",
+        "beta[2,1]",
+        "beta[1,2]",
+        "beta[2,2]",
+        "sigma"
+      )),
+      esr = c(0.011, 0.011, 0.05, 0.05, 0.05, 0.05, 0.472)
+    )
+  )
 })
 
 
 test_that("esr.mcmcr", {
   expect_identical(esr(mcmcr_example2), 0.011)
   expect_identical(esr(mcmcr_example), 0.011)
-  expect_identical(esr(mcmcr_example, as_df = TRUE), tibble(all = "all", esr = 0.011))
-  expect_identical(esr(mcmcr_example, by = "parameter"), list(alpha = 0.011, beta = 0.05, sigma = 0.472))
-  expect_equal(esr(mcmcr_example, by = "term"), list(alpha = c(0.011, 0.011), beta = matrix(c(0.05, 0.05, 0.05, 0.05), nrow = 2, ncol = 2), sigma = 0.472))
-  expect_equal(esr(mcmcr_example, by = "term", as_df = TRUE), tibble(term = as_term(c("alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]", "beta[1,2]", "beta[2,2]", "sigma")), esr = c(0.011, 0.011, 0.05, 0.05, 0.05, 0.05, 0.472)))
+  expect_identical(
+    esr(mcmcr_example, as_df = TRUE),
+    tibble(all = "all", esr = 0.011)
+  )
+  expect_identical(
+    esr(mcmcr_example, by = "parameter"),
+    list(alpha = 0.011, beta = 0.05, sigma = 0.472)
+  )
+  expect_equal(
+    esr(mcmcr_example, by = "term"),
+    list(
+      alpha = c(0.011, 0.011),
+      beta = matrix(c(0.05, 0.05, 0.05, 0.05), nrow = 2, ncol = 2),
+      sigma = 0.472
+    )
+  )
+  expect_equal(
+    esr(mcmcr_example, by = "term", as_df = TRUE),
+    tibble(
+      term = as_term(c(
+        "alpha[1]",
+        "alpha[2]",
+        "beta[1,1]",
+        "beta[2,1]",
+        "beta[1,2]",
+        "beta[2,2]",
+        "sigma"
+      )),
+      esr = c(0.011, 0.011, 0.05, 0.05, 0.05, 0.05, 0.472)
+    )
+  )
 })
 
 test_that("esr.mcmcr NA", {
@@ -79,13 +205,19 @@ test_that("esr.mcmcr NA", {
   x$alpha[1, 1, 1, 1, 1] <- NA_real_
   expect_identical(esr(x), NA_real_)
   expect_identical(esr(x, na_rm = TRUE), 0.011)
-  expect_identical(esr(x, by = "parameter"), list(alpha = NA_real_, beta = 0.05, sigma = 0.472))
-  expect_identical(esr(x, by = "parameter", na_rm = TRUE), list(alpha = 0.011, beta = 0.05, sigma = 0.472))
+  expect_identical(
+    esr(x, by = "parameter"),
+    list(alpha = NA_real_, beta = 0.05, sigma = 0.472)
+  )
+  expect_identical(
+    esr(x, by = "parameter", na_rm = TRUE),
+    list(alpha = 0.011, beta = 0.05, sigma = 0.472)
+  )
 })
 
 test_that("esr.mcmcr constant", {
   x <- mcmcr::mcmcr_example
-  x$sigma[, , 1] <- 0
+  x$sigma[,, 1] <- 0
 
   expect_identical(esr(x$sigma), 1)
 
@@ -93,12 +225,23 @@ test_that("esr.mcmcr constant", {
 })
 
 test_that("esr.mcmcrs", {
-  expect_identical(esr(mcmcrs(mcmcr_example, mcmcr_example)), list(mcmcr1 = 0.011, mcmcr2 = 0.011))
+  expect_identical(
+    esr(mcmcrs(mcmcr_example, mcmcr_example)),
+    list(mcmcr1 = 0.011, mcmcr2 = 0.011)
+  )
 })
 
 test_that("esr.mcmcarray constant", {
-  x <- structure(rep(-0.75377180237638, 300), dim = c(3L, 100L, 1L), class = "mcmcarray")
+  x <- structure(
+    rep(-0.75377180237638, 300),
+    dim = c(3L, 100L, 1L),
+    class = "mcmcarray"
+  )
   expect_identical(esr(x), 1)
-  x <- structure(rep(-0.75377180237638, 30), dim = c(3L, 10L, 1L), class = "mcmcarray")
+  x <- structure(
+    rep(-0.75377180237638, 30),
+    dim = c(3L, 10L, 1L),
+    class = "mcmcarray"
+  )
   expect_identical(esr(x), 1)
 })

--- a/tests/testthat/test-ess.R
+++ b/tests/testthat/test-ess.R
@@ -1,24 +1,38 @@
 test_that("ess.mcmcmarray", {
   expect_identical(ess(mcmcr_example[[1]], by = "term"), c(9L, 9L))
-  expect_equal(ess(mcmcr_example[[2]], by = "term"), matrix(c(40L, 40L, 40L, 40L), nrow = 2))
+  expect_equal(
+    ess(mcmcr_example[[2]], by = "term"),
+    matrix(c(40L, 40L, 40L, 40L), nrow = 2)
+  )
   expect_identical(ess(mcmcr_example[[3]], by = "term"), c(378L))
   expect_identical(ess(mcmcr_example[[2]]), 40L)
-  expect_identical(ess(mcmcr_example[[1]], "parameter"), ess(mcmcr_example[[1]], "all"))
+  expect_identical(
+    ess(mcmcr_example[[1]], "parameter"),
+    ess(mcmcr_example[[1]], "all")
+  )
 })
 
 test_that("ess.mcmcr", {
   expect_identical(ess(mcmcr_example2), 9L)
   expect_identical(ess(mcmcr_example), 9L)
-  expect_identical(ess(mcmcr_example, by = "parameter"), list(alpha = 9L, beta = 40L, sigma = 378L))
+  expect_identical(
+    ess(mcmcr_example, by = "parameter"),
+    list(alpha = 9L, beta = 40L, sigma = 378L)
+  )
 })
 
 test_that("ess.mcmcr as df", {
   expect_identical(
     ess(mcmcr_example, as_df = TRUE),
-    structure(list(all = "all", ess = 9L), row.names = c(NA, -1L), class = c(
-      "tbl_df",
-      "tbl", "data.frame"
-    ))
+    structure(
+      list(all = "all", ess = 9L),
+      row.names = c(NA, -1L),
+      class = c(
+        "tbl_df",
+        "tbl",
+        "data.frame"
+      )
+    )
   )
   expect_snapshot_data(
     ess(mcmcr_example, as_df = TRUE, by = "parameter"),
@@ -28,15 +42,23 @@ test_that("ess.mcmcr as df", {
 
 test_that("ess.mcmcr constant", {
   x <- mcmcr::mcmcr_example
-  x$sigma[, , 1] <- 0
+  x$sigma[,, 1] <- 0
 
   expect_identical(ess(x$sigma), 800L)
   expect_identical(ess(x), 9L)
 })
 
 test_that("ess.mcmcarray constant", {
-  x <- structure(rep(-0.75377180237638, 300), dim = c(3L, 100L, 1L), class = "mcmcarray")
+  x <- structure(
+    rep(-0.75377180237638, 300),
+    dim = c(3L, 100L, 1L),
+    class = "mcmcarray"
+  )
   expect_identical(ess(x), 300L)
-  x <- structure(rep(-0.75377180237638, 30), dim = c(3L, 10L, 1L), class = "mcmcarray")
+  x <- structure(
+    rep(-0.75377180237638, 30),
+    dim = c(3L, 10L, 1L),
+    class = "mcmcarray"
+  )
   expect_identical(ess(x), 30L)
 })

--- a/tests/testthat/test-estimates.R
+++ b/tests/testthat/test-estimates.R
@@ -10,58 +10,125 @@ test_that("estimates.mcarray", {
 test_that("estimates.mcmcarray", {
   expect_equal(estimates(mcmcr_example[[1]]), c(3.718025, 4.718025))
   expect_equal(estimates(mcmcr_example[[3]]), c(0.7911975))
-  expect_identical(estimates(mcmcr_example)$alpha, estimates(mcmcr_example[[1]]))
+  expect_identical(
+    estimates(mcmcr_example)$alpha,
+    estimates(mcmcr_example[[1]])
+  )
 })
 
 test_that("estimates.mcmc", {
-  expect_equal(estimates(as.mcmc(collapse_chains(mcmcr_example)))$alpha, c(3.718025, 4.718025))
+  expect_equal(
+    estimates(as.mcmc(collapse_chains(mcmcr_example)))$alpha,
+    c(3.718025, 4.718025)
+  )
   expect_equal(
     estimates(as.mcmc(collapse_chains(mcmcr_example)), as_df = TRUE)$estimate,
     c(
-      3.718025, 4.718025, 0.9716535, 1.9716535, 1.9716535, 2.9716535,
+      3.718025,
+      4.718025,
+      0.9716535,
+      1.9716535,
+      1.9716535,
+      2.9716535,
       0.7911975
     )
   )
 })
 
 test_that("estimates.mcmc.list", {
-  expect_equal(estimates(coda::as.mcmc.list(mcmcr_example))$alpha, c(3.718025, 4.718025))
+  expect_equal(
+    estimates(coda::as.mcmc.list(mcmcr_example))$alpha,
+    c(3.718025, 4.718025)
+  )
   expect_equal(
     estimates(coda::as.mcmc.list(mcmcr_example), as_df = TRUE)$estimate,
     c(
-      3.718025, 4.718025, 0.9716535, 1.9716535, 1.9716535, 2.9716535,
+      3.718025,
+      4.718025,
+      0.9716535,
+      1.9716535,
+      1.9716535,
+      2.9716535,
       0.7911975
     )
   )
 })
 
 test_that("estimates not as list", {
-  expect_equal(estimates(mcmcr_example[[1]], as_df = TRUE), tibble(term = as_term(c("parameter[1]", "parameter[2]")), estimate = estimates(mcmcr_example[[1]])))
-  expect_equal(estimates(mcmcr_example[[2]], as_df = TRUE), tibble(term = as_term(c("parameter[1,1]", "parameter[2,1]", "parameter[1,2]", "parameter[2,2]")), estimate = as.vector(estimates(mcmcr_example[[2]]))))
-  expect_equal(estimates(mcmcr_example[[3]], as_df = TRUE), tibble(term = as_term("parameter"), estimate = estimates(mcmcr_example[[3]])))
-  expect_identical(sort(estimates(mcmcr_example, as_df = TRUE)$term), sort(as_term(c("alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]", "beta[1,2]", "beta[2,2]", "sigma"))))
+  expect_equal(
+    estimates(mcmcr_example[[1]], as_df = TRUE),
+    tibble(
+      term = as_term(c("parameter[1]", "parameter[2]")),
+      estimate = estimates(mcmcr_example[[1]])
+    )
+  )
+  expect_equal(
+    estimates(mcmcr_example[[2]], as_df = TRUE),
+    tibble(
+      term = as_term(c(
+        "parameter[1,1]",
+        "parameter[2,1]",
+        "parameter[1,2]",
+        "parameter[2,2]"
+      )),
+      estimate = as.vector(estimates(mcmcr_example[[2]]))
+    )
+  )
+  expect_equal(
+    estimates(mcmcr_example[[3]], as_df = TRUE),
+    tibble(
+      term = as_term("parameter"),
+      estimate = estimates(mcmcr_example[[3]])
+    )
+  )
+  expect_identical(
+    sort(estimates(mcmcr_example, as_df = TRUE)$term),
+    sort(as_term(c(
+      "alpha[1]",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
+    )))
+  )
 })
 
 test_that("estimates not as list", {
-  expect_equal(estimates(mcmcr_example[[3]], fun = sum), 774.4415, tolerance = 0.0000001)
-  expect_equal(estimates(mcmcr_example[[3]], fun = sum, as_df = TRUE)$estimate, 774.4415, tolerance = 0.0000001)
+  expect_equal(
+    estimates(mcmcr_example[[3]], fun = sum),
+    774.4415,
+    tolerance = 0.0000001
+  )
+  expect_equal(
+    estimates(mcmcr_example[[3]], fun = sum, as_df = TRUE)$estimate,
+    774.4415,
+    tolerance = 0.0000001
+  )
   expect_identical(estimates(mcmcr_example[[3]], fun = length), 800L)
-  expect_identical(estimates(mcmcr_example[[3]], fun = length, as_df = TRUE)$estimate, 800L)
+  expect_identical(
+    estimates(mcmcr_example[[3]], fun = length, as_df = TRUE)$estimate,
+    800L
+  )
 })
 
 test_that("estimates not scalar", {
-  expect_error(estimates(mcmcr::mcmcr_example, fun = function(x) NULL),
+  expect_error(
+    estimates(mcmcr::mcmcr_example, fun = function(x) NULL),
     "^`fun` must return a scalar[.]$",
     class = "chk_error"
   )
-  expect_error(estimates(mcmcr::mcmcr_example, fun = identity),
+  expect_error(
+    estimates(mcmcr::mcmcr_example, fun = identity),
     "^`fun` must return a scalar[.]$",
     class = "chk_error"
   )
 })
 
 test_that("estimates not numeric", {
-  expect_error(estimates(mcmcr::mcmcr_example, fun = function(x) as.character(sum(x))),
+  expect_error(
+    estimates(mcmcr::mcmcr_example, fun = function(x) as.character(sum(x))),
     "^`fun` must return a numeric[.]$",
     class = "chk_error"
   )
@@ -70,7 +137,9 @@ test_that("estimates not numeric", {
 test_that("estimates ...", {
   mean1 <- function(x, plus_one = FALSE) {
     x <- mean(x)
-    if (isFALSE(plus_one)) return(x)
+    if (isFALSE(plus_one)) {
+      return(x)
+    }
     x + 1
   }
 

--- a/tests/testthat/test-fill-all.R
+++ b/tests/testthat/test-fill-all.R
@@ -1,11 +1,19 @@
 test_that("fill_all.mcarray", {
   mcarray <- as.mcarray(mcmcr_example[[2]])
-  expect_equal(estimates(fill_all(mcarray)), matrix(0, nrow = 2, ncol = 2), ignore_attr = FALSE)
+  expect_equal(
+    estimates(fill_all(mcarray)),
+    matrix(0, nrow = 2, ncol = 2),
+    ignore_attr = FALSE
+  )
 })
 
 test_that("fill_all.mcmcarray", {
   mcmcarray <- mcmcr_example[[2]]
-  expect_equal(estimates(fill_all(mcmcarray)), matrix(0, nrow = 2, ncol = 2), ignore_attr = FALSE)
+  expect_equal(
+    estimates(fill_all(mcmcarray)),
+    matrix(0, nrow = 2, ncol = 2),
+    ignore_attr = FALSE
+  )
 })
 #
 # test_that("fill_all.mcmcr", {

--- a/tests/testthat/test-fill-na.R
+++ b/tests/testthat/test-fill-na.R
@@ -1,13 +1,21 @@
 test_that("fill_na.mcarray", {
   mcarray <- as.mcarray(mcmcr_example[[2]])
   mcarray <- fill_all(mcarray, NA_real_)
-  expect_equal(estimates(fill_na(mcarray, 1)), matrix(1, nrow = 2, ncol = 2), ignore_attr = FALSE)
+  expect_equal(
+    estimates(fill_na(mcarray, 1)),
+    matrix(1, nrow = 2, ncol = 2),
+    ignore_attr = FALSE
+  )
 })
 
 test_that("fill_na.mcmcarray", {
   mcmcarray <- mcmcr_example[[2]]
   mcmcarray <- fill_all(mcmcarray, NA_real_)
-  expect_equal(estimates(fill_na(mcmcarray, 2)), matrix(2, nrow = 2, ncol = 2), ignore_attr = FALSE)
+  expect_equal(
+    estimates(fill_na(mcmcarray, 2)),
+    matrix(2, nrow = 2, ncol = 2),
+    ignore_attr = FALSE
+  )
 })
 #
 # test_that("fill_na.mcmcr", {

--- a/tests/testthat/test-mcmc-aperm.R
+++ b/tests/testthat/test-mcmc-aperm.R
@@ -1,5 +1,8 @@
 test_that("mcmc_aperm", {
-  expect_identical(mcmc_aperm(mcmcr_example[[1]], perm = 1L), mcmcr_example[[1]])
+  expect_identical(
+    mcmc_aperm(mcmcr_example[[1]], perm = 1L),
+    mcmcr_example[[1]]
+  )
   expect_identical(mcmc_aperm(mcmcr_example[[1]]), mcmcr_example[[1]])
 })
 
@@ -30,5 +33,8 @@ test_that("mcmc_aperm.mcmcr", {
 })
 
 test_that("mcmc_aperm.mcmcrs", {
-  expect_identical(mcmc_aperm(as.mcmcrs(list(mcmcr_example, mcmcr_example)), perm = 1L), as.mcmcrs(list(mcmcr_example, mcmcr_example)))
+  expect_identical(
+    mcmc_aperm(as.mcmcrs(list(mcmcr_example, mcmcr_example)), perm = 1L),
+    as.mcmcrs(list(mcmcr_example, mcmcr_example))
+  )
 })

--- a/tests/testthat/test-mcmc-map.R
+++ b/tests/testthat/test-mcmc-map.R
@@ -1,18 +1,51 @@
 test_that("mcmc_map", {
   expect_identical(mcmc_map(mcmcr_example[[1]], identity), mcmcr_example[[1]])
-  expect_identical(mcmc_map(mcmcr_example[[1]], function(x) x * 10), mcmcr_example[[1]] * 10)
-  expect_identical(mcmc_map(as.mcmc.list(mcmcr_example[[1]]), function(x) x * 10), as.mcmc.list(mcmcr_example[[1]] * 10))
+  expect_identical(
+    mcmc_map(mcmcr_example[[1]], function(x) x * 10),
+    mcmcr_example[[1]] * 10
+  )
+  expect_identical(
+    mcmc_map(as.mcmc.list(mcmcr_example[[1]]), function(x) x * 10),
+    as.mcmc.list(mcmcr_example[[1]] * 10)
+  )
   expect_error(mcmc_map(mcmcr_example[[1]], function(x) c(x, x)))
-  expect_identical(sum(mcmc_map(mcmcr_example[[1]], function(x) (x * 2))), sum(mcmcr_example[[1]]) * 2)
+  expect_identical(
+    sum(mcmc_map(mcmcr_example[[1]], function(x) (x * 2))),
+    sum(mcmcr_example[[1]]) * 2
+  )
   expect_s3_class(mcmc_map(mcmcr_example, function(x) x * 5), "mcmcr")
-  expect_identical(mcmc_map(mcmcr_example, function(x) x * 5)[[2]], mcmcr_example[[2]] * 5)
+  expect_identical(
+    mcmc_map(mcmcr_example, function(x) x * 5)[[2]],
+    mcmcr_example[[2]] * 5
+  )
 })
 
 test_that("mcmc_map with vector", {
-  expect_identical(mcmc_map(mcmcr_example[[1]], .f = function(x) x / 1, .by = TRUE), mcmcr_example[[1]])
-  expect_identical(mcmc_map(mcmcr_example[[1]], .f = function(x) x / 1, .by = FALSE), mcmcr_example[[1]])
-  expect_identical(estimates(mcmc_map(mcmcr_example[[1]], .f = function(x) x / sum(x), .by = TRUE)), c(1, 1))
-  expect_equal(estimates(mcmc_map(mcmcr_example[[1]], .f = function(x) x / sum(x), .by = FALSE)), c(0.4407305, 0.5592695), tolerance = 1e-07)
+  expect_identical(
+    mcmc_map(mcmcr_example[[1]], .f = function(x) x / 1, .by = TRUE),
+    mcmcr_example[[1]]
+  )
+  expect_identical(
+    mcmc_map(mcmcr_example[[1]], .f = function(x) x / 1, .by = FALSE),
+    mcmcr_example[[1]]
+  )
+  expect_identical(
+    estimates(mcmc_map(
+      mcmcr_example[[1]],
+      .f = function(x) x / sum(x),
+      .by = TRUE
+    )),
+    c(1, 1)
+  )
+  expect_equal(
+    estimates(mcmc_map(
+      mcmcr_example[[1]],
+      .f = function(x) x / sum(x),
+      .by = FALSE
+    )),
+    c(0.4407305, 0.5592695),
+    tolerance = 1e-07
+  )
 })
 
 test_that("mcmc_map with arrays identical", {
@@ -29,8 +62,20 @@ test_that("mcmc_map with arrays identical", {
 test_that("mcmc_map with arrays rescale", {
   x <- array(1:prod(2:7), dim = 2:7)
   class(x) <- "mcmcarray"
-  expect_identical(estimates(mcmc_map(x, .f = function(x) x / sum(x))), array(1, dim = 4:7))
-  expect_identical(sum(estimates(mcmc_map(x, .f = function(x) x / sum(x)))), 840)
-  expect_equal(sum(estimates(mcmc_map(x, .f = function(x) x / sum(x), .by = FALSE))), 1)
-  expect_identical(sum(estimates(mcmc_map(x, .f = function(x) x / sum(x), .by = c(2L, 4L)))), 35)
+  expect_identical(
+    estimates(mcmc_map(x, .f = function(x) x / sum(x))),
+    array(1, dim = 4:7)
+  )
+  expect_identical(
+    sum(estimates(mcmc_map(x, .f = function(x) x / sum(x)))),
+    840
+  )
+  expect_equal(
+    sum(estimates(mcmc_map(x, .f = function(x) x / sum(x), .by = FALSE))),
+    1
+  )
+  expect_identical(
+    sum(estimates(mcmc_map(x, .f = function(x) x / sum(x), .by = c(2L, 4L)))),
+    35
+  )
 })

--- a/tests/testthat/test-npdims.R
+++ b/tests/testthat/test-npdims.R
@@ -1,5 +1,8 @@
 test_that("npdims", {
   expect_identical(npdims(mcmcr_example2), c(alpha = 3L, beta = 3L, sigma = 3L))
   expect_identical(npdims(mcmcr_example), c(alpha = 1L, beta = 2L, sigma = 1L))
-  expect_identical(npdims(as.mcmc.list(mcmcr_example)), c(alpha = 1L, beta = 2L, sigma = 1L))
+  expect_identical(
+    npdims(as.mcmc.list(mcmcr_example)),
+    c(alpha = 1L, beta = 2L, sigma = 1L)
+  )
 })

--- a/tests/testthat/test-nsims.R
+++ b/tests/testthat/test-nsims.R
@@ -1,7 +1,13 @@
 test_that("nsims", {
   expect_identical(nsims(mcmcr::mcmcr_example), 800L)
   expect_identical(nsims(as.mcmc.list(mcmcr::mcmcr_example)), 800L)
-  expect_identical(nsims(as.mcmc(subset(mcmcr::mcmcr_example, chains = 1L))), 400L)
+  expect_identical(
+    nsims(as.mcmc(subset(mcmcr::mcmcr_example, chains = 1L))),
+    400L
+  )
   expect_identical(nsims(as.mcarray(mcmcr::mcmcr_example[[1]])), 800L)
-  expect_identical(nsims(mcmcrs(mcmcr::mcmcr_example, mcmcr::mcmcr_example)), 800L)
+  expect_identical(
+    nsims(mcmcrs(mcmcr::mcmcr_example, mcmcr::mcmcr_example)),
+    800L
+  )
 })

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -1,9 +1,15 @@
 test_that("parameters.mcmcr", {
   rlang::local_options(lifecycle_verbosity = "quiet")
   lifecycle::expect_deprecated(parameters(mcmcr::mcmcr_example))
-  expect_identical(parameters(mcmcr::mcmcr_example), c("alpha", "beta", "sigma"))
+  expect_identical(
+    parameters(mcmcr::mcmcr_example),
+    c("alpha", "beta", "sigma")
+  )
   expect_identical(parameters(mcmcr::mcmcr_example, scalar = TRUE), c("sigma"))
-  expect_identical(parameters(mcmcr::mcmcr_example, scalar = FALSE), c("alpha", "beta"))
+  expect_identical(
+    parameters(mcmcr::mcmcr_example, scalar = FALSE),
+    c("alpha", "beta")
+  )
   parameters(mcmcr_example) <- c("alpha1", "alpha2", "alpha3")
   expect_identical(parameters(mcmcr_example), c("alpha1", "alpha2", "alpha3"))
 })

--- a/tests/testthat/test-pars.R
+++ b/tests/testthat/test-pars.R
@@ -1,7 +1,10 @@
 test_that("pars.mcmcr", {
   expect_identical(pars(mcmcr::mcmcr_example), c("alpha", "beta", "sigma"))
   expect_identical(pars(mcmcr::mcmcr_example, scalar = TRUE), c("sigma"))
-  expect_identical(pars(mcmcr::mcmcr_example, scalar = FALSE), c("alpha", "beta"))
+  expect_identical(
+    pars(mcmcr::mcmcr_example, scalar = FALSE),
+    c("alpha", "beta")
+  )
   pars(mcmcr_example) <- c("alpha1", "alpha2", "alpha3")
   expect_identical(pars(mcmcr_example), c("alpha1", "alpha2", "alpha3"))
 })

--- a/tests/testthat/test-pdims.R
+++ b/tests/testthat/test-pdims.R
@@ -1,9 +1,24 @@
 test_that("pdims", {
-  expect_identical(pdims(mcmcr_example2), list(alpha = c(2L, 1L, 1L), beta = c(2L, 2L, 2L), sigma = c(1L, 1L, 1L)))
-  expect_identical(pdims(mcmcr_example), list(alpha = 2L, beta = c(2L, 2L), sigma = 1L))
+  expect_identical(
+    pdims(mcmcr_example2),
+    list(alpha = c(2L, 1L, 1L), beta = c(2L, 2L, 2L), sigma = c(1L, 1L, 1L))
+  )
+  expect_identical(
+    pdims(mcmcr_example),
+    list(alpha = 2L, beta = c(2L, 2L), sigma = 1L)
+  )
   expect_identical(pdims(mcmcr_example[[1]]), 2L)
   expect_identical(pdims(mcmcr_example2[[1]]), c(2L, 1L, 1L))
-  expect_identical(pdims(as_term(as.mcmc.list(mcmcr_example[[1]])[[1]])), list(parameter = 2L))
-  expect_identical(pdims(as.mcmc.list(mcmcr_example[[1]])[[1]]), list(parameter = 2L))
-  expect_identical(pdims(as.mcmc.list(mcmcr_example[[1]])), list(parameter = 2L))
+  expect_identical(
+    pdims(as_term(as.mcmc.list(mcmcr_example[[1]])[[1]])),
+    list(parameter = 2L)
+  )
+  expect_identical(
+    pdims(as.mcmc.list(mcmcr_example[[1]])[[1]]),
+    list(parameter = 2L)
+  )
+  expect_identical(
+    pdims(as.mcmc.list(mcmcr_example[[1]])),
+    list(parameter = 2L)
+  )
 })

--- a/tests/testthat/test-rhat.R
+++ b/tests/testthat/test-rhat.R
@@ -35,36 +35,91 @@ test_that("rhat.mcmcmarray", {
 
   expect_identical(
     rhat(mcmcr_example[[1]], as_df = TRUE, by = "all"),
-    structure(list(parameter = "parameter", rhat = 2.002),
-      class = c("tbl_df", "tbl", "data.frame"), row.names = c(NA, -1L)
+    structure(
+      list(parameter = "parameter", rhat = 2.002),
+      class = c("tbl_df", "tbl", "data.frame"),
+      row.names = c(NA, -1L)
     )
   )
 
-  expect_equal(rhat(mcmcr_example[[2]], by = "term"), matrix(c(1.147, 1.147, 1.147, 1.147), nrow = 2, ncol = 2))
+  expect_equal(
+    rhat(mcmcr_example[[2]], by = "term"),
+    matrix(c(1.147, 1.147, 1.147, 1.147), nrow = 2, ncol = 2)
+  )
 
   expect_identical(rhat(mcmcr_example[[2]]), 1.147)
-  expect_equal(rhat(mcmcr_example[[2]], by = "term", as_df = TRUE)$term, as_term(c("parameter[1,1]", "parameter[2,1]", "parameter[1,2]", "parameter[2,2]")))
-  expect_equal(rhat(mcmcr_example[[2]], by = "term", as_df = TRUE)$rhat, c(1.147, 1.147, 1.147, 1.147))
+  expect_equal(
+    rhat(mcmcr_example[[2]], by = "term", as_df = TRUE)$term,
+    as_term(c(
+      "parameter[1,1]",
+      "parameter[2,1]",
+      "parameter[1,2]",
+      "parameter[2,2]"
+    ))
+  )
+  expect_equal(
+    rhat(mcmcr_example[[2]], by = "term", as_df = TRUE)$rhat,
+    c(1.147, 1.147, 1.147, 1.147)
+  )
 
-  expect_identical(rhat(subset(mcmcr_example[[2]], iters = 1L), by = "term", as_df = TRUE)$rhat, rep(NA_real_, 4))
-  expect_identical(rhat(mcmcr_example[[1]], "parameter"), rhat(mcmcr_example[[1]], "all"))
+  expect_identical(
+    rhat(
+      subset(mcmcr_example[[2]], iters = 1L),
+      by = "term",
+      as_df = TRUE
+    )$rhat,
+    rep(NA_real_, 4)
+  )
+  expect_identical(
+    rhat(mcmcr_example[[1]], "parameter"),
+    rhat(mcmcr_example[[1]], "all")
+  )
 })
 
 test_that("rhat.mcmcr", {
   expect_identical(rhat(mcmcr_example2), 2.002)
   expect_identical(
     rhat(mcmcr_example, as_df = TRUE),
-    structure(list(all = "all", rhat = 2.002),
+    structure(
+      list(all = "all", rhat = 2.002),
       class = c("tbl_df", "tbl", "data.frame"),
       row.names = c(NA, -1L)
     )
   )
 
   expect_identical(rhat(mcmcr_example), 2.002)
-  expect_identical(rhat(mcmcr_example, by = "parameter"), list(alpha = 2.002, beta = 1.147, sigma = 1))
-  expect_equal(rhat(mcmcr_example, by = "parameter", as_df = TRUE), tibble(parameter = c("alpha", "beta", "sigma"), rhat = c(2.002, 1.147, 1)), ignore_attr = FALSE)
-  expect_equal(rhat(mcmcr_example, by = "term"), list(alpha = c(2.002, 2.002), beta = matrix(c(1.147, 1.147, 1.147, 1.147), nrow = 2.002, ncol = 2), sigma = 1))
-  expect_equal(rhat(mcmcr_example, by = "term", as_df = TRUE), tibble(term = as_term(c("alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]", "beta[1,2]", "beta[2,2]", "sigma")), rhat = c(2.002, 2.002, 1.147, 1.147, 1.147, 1.147, 1)))
+  expect_identical(
+    rhat(mcmcr_example, by = "parameter"),
+    list(alpha = 2.002, beta = 1.147, sigma = 1)
+  )
+  expect_equal(
+    rhat(mcmcr_example, by = "parameter", as_df = TRUE),
+    tibble(parameter = c("alpha", "beta", "sigma"), rhat = c(2.002, 1.147, 1)),
+    ignore_attr = FALSE
+  )
+  expect_equal(
+    rhat(mcmcr_example, by = "term"),
+    list(
+      alpha = c(2.002, 2.002),
+      beta = matrix(c(1.147, 1.147, 1.147, 1.147), nrow = 2.002, ncol = 2),
+      sigma = 1
+    )
+  )
+  expect_equal(
+    rhat(mcmcr_example, by = "term", as_df = TRUE),
+    tibble(
+      term = as_term(c(
+        "alpha[1]",
+        "alpha[2]",
+        "beta[1,1]",
+        "beta[2,1]",
+        "beta[1,2]",
+        "beta[2,2]",
+        "sigma"
+      )),
+      rhat = c(2.002, 2.002, 1.147, 1.147, 1.147, 1.147, 1)
+    )
+  )
 })
 
 test_that("rhat.mcmcr NA", {
@@ -72,8 +127,14 @@ test_that("rhat.mcmcr NA", {
   x$alpha[1, 1, 1, 1, 1] <- NA_real_
   expect_identical(rhat(x), NA_real_)
   expect_identical(rhat(x, na_rm = TRUE), 2.085)
-  expect_identical(rhat(x, by = "parameter"), list(alpha = NA_real_, beta = 1.147, sigma = 1))
-  expect_identical(rhat(x, by = "parameter", na_rm = TRUE), list(alpha = 2.085, beta = 1.147, sigma = 1))
+  expect_identical(
+    rhat(x, by = "parameter"),
+    list(alpha = NA_real_, beta = 1.147, sigma = 1)
+  )
+  expect_identical(
+    rhat(x, by = "parameter", na_rm = TRUE),
+    list(alpha = 2.085, beta = 1.147, sigma = 1)
+  )
 })
 
 test_that("rhat.mcmcrs", {
@@ -102,7 +163,11 @@ test_that("rhat.mcmcrs", {
 
   lifecycle::expect_deprecated(
     expect_identical(
-      rhat(mcmcrs(mcmcr_example, mcmcr_example), bound = TRUE, by = "parameter"),
+      rhat(
+        mcmcrs(mcmcr_example, mcmcr_example),
+        bound = TRUE,
+        by = "parameter"
+      ),
       list(
         mcmcr1 = list(alpha = 2.002, beta = 1.147, sigma = 1),
         mcmcr2 = list(alpha = 2.002, beta = 1.147, sigma = 1),
@@ -117,7 +182,8 @@ test_that("rhat.mcmcrs", {
       rhat(mcmcrs(mcmcr_example, mcmcr_example), bound = TRUE, as_df = TRUE),
       structure(
         list(all = "all", mcmcr1 = 2.002, mcmcr2 = 2.002, bound = 1.891),
-        class = "data.frame", row.names = c(NA, -1L)
+        class = "data.frame",
+        row.names = c(NA, -1L)
       )
     ),
     regexp = "`rhat.mcmcrs\\(x, bound = TRUE\\)` returns scalar was deprecated in mcmcr 0.6.1.9001."
@@ -127,7 +193,9 @@ test_that("rhat.mcmcrs", {
     expect_identical(
       rhat(
         mcmcrs(mcmcr_example, mcmcr_example),
-        by = "parameter", bound = TRUE, as_df = TRUE
+        by = "parameter",
+        bound = TRUE,
+        as_df = TRUE
       ),
       structure(
         list(
@@ -147,12 +215,22 @@ test_that("rhat.mcmcrs", {
     expect_identical(
       rhat(
         mcmcrs(mcmcr_example, mcmcr_example),
-        by = "term", bound = TRUE, as_df = TRUE
+        by = "term",
+        bound = TRUE,
+        as_df = TRUE
       ),
       structure(
         list(
           term = structure(
-            c("alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]", "beta[1,2]", "beta[2,2]", "sigma"),
+            c(
+              "alpha[1]",
+              "alpha[2]",
+              "beta[1,1]",
+              "beta[2,1]",
+              "beta[1,2]",
+              "beta[2,2]",
+              "sigma"
+            ),
             class = c("term", "vctrs_vctr")
           ),
           mcmcr1 = c(2.002, 2.002, 1.147, 1.147, 1.147, 1.147, 1),

--- a/tests/testthat/test-split-chains.R
+++ b/tests/testthat/test-split-chains.R
@@ -7,7 +7,9 @@ test_that("split_chains.mcmcarray", {
 
 test_that("split_chains 1 iterations", {
   x <- subset(mcmcr_example, iters = 1L)
-  expect_error(split_chains(x), "^`x` must have at least two iterations[.]$",
+  expect_error(
+    split_chains(x),
+    "^`x` must have at least two iterations[.]$",
     class = "chk_error"
   )
   x <- subset(mcmcr_example, iters = 1:2)

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -1,5 +1,8 @@
 test_that("subset.mcmcr", {
-  expect_identical(pars(subset(mcmcr_example, pars = rev(pars(mcmcr_example)))), rev(pars(mcmcr_example)))
+  expect_identical(
+    pars(subset(mcmcr_example, pars = rev(pars(mcmcr_example)))),
+    rev(pars(mcmcr_example))
+  )
   expect_identical(nchains(subset(mcmcr_example, 1L)), 1L)
   expect_identical(nsims(subset(mcmcr_example, rep(1L, 5), 2:3)), 10L)
   expect_identical(nterms(subset(mcmcr_example, pars = "beta")), 4L)
@@ -7,14 +10,23 @@ test_that("subset.mcmcr", {
 
 test_that("subset.mcmcrs", {
   mcmcrs <- mcmcrs(mcmcr::mcmcr_example, mcmcr::mcmcr_example)
-  expect_identical(pars(subset(mcmcrs, pars = rev(pars(mcmcrs)))), rev(pars(mcmcrs)))
+  expect_identical(
+    pars(subset(mcmcrs, pars = rev(pars(mcmcrs)))),
+    rev(pars(mcmcrs))
+  )
   expect_identical(nchains(subset(mcmcrs, 1L)), 1L)
   expect_identical(nsims(subset(mcmcrs, rep(1L, 5), 2:3)), 10L)
   expect_identical(nterms(subset(mcmcrs, pars = "beta")), 4L)
 })
 
 test_that("subset.mcmc.list", {
-  expect_identical(pars(subset(as.mcmc.list(mcmcr_example), pars = "beta")), "beta")
+  expect_identical(
+    pars(subset(as.mcmc.list(mcmcr_example), pars = "beta")),
+    "beta"
+  )
   expect_identical(niters(subset(as.mcmc.list(mcmcr_example), iters = 10L)), 1L)
-  expect_identical(nchains(subset(as.mcmc.list(mcmcr_example), chains = 2L)), 1L)
+  expect_identical(
+    nchains(subset(as.mcmc.list(mcmcr_example), chains = 2L)),
+    1L
+  )
 })

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -1,10 +1,14 @@
 test_that("summary.mcmcarray", {
   expect_equal(
     summary(mcmcr_example$alpha),
-    structure(list(
-      estimates = c(3.718025, 4.718025), nchains = 2L,
-      niters = 400L
-    ), class = "summary.mcmcarray")
+    structure(
+      list(
+        estimates = c(3.718025, 4.718025),
+        nchains = 2L,
+        niters = 400L
+      ),
+      class = "summary.mcmcarray"
+    )
   )
 })
 

--- a/tests/testthat/test-tidy.R
+++ b/tests/testthat/test-tidy.R
@@ -1,4 +1,7 @@
 test_that("tidy.mcmcr", {
   x <- subset(mcmcr::mcmcr_example, iters = 1:2)
-  expect_identical(tidy(x, simplify = TRUE), tidy(nlist::as_mcmc_list(x), simplify = TRUE))
+  expect_identical(
+    tidy(x, simplify = TRUE),
+    tidy(nlist::as_mcmc_list(x), simplify = TRUE)
+  )
 })

--- a/tests/testthat/test-vld.R
+++ b/tests/testthat/test-vld.R
@@ -5,7 +5,9 @@ test_that("vld_mcmcarray", {
 
   x <- array(TRUE)
   class(x) <- "mcmcarray"
-  expect_error(chk_mcmcarray(x), "^`x` must be numeric[.]$",
+  expect_error(
+    chk_mcmcarray(x),
+    "^`x` must be numeric[.]$",
     class = "chk_error"
   )
 


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)