### PR TITLE
Make coef(simplify = FALSE) defunct and escalate rhat.mcmcrs(bound = TRUE) deprecation

### DIFF
--- a/R/coef.R
+++ b/R/coef.R
@@ -46,7 +46,7 @@ coef_numeric_impl <- function(
   chk_flag(directional_information)
 
   if (!simplify) {
-    lifecycle::deprecate_warn("0.4.1", "coef(simplify = 'must be TRUE')")
+    lifecycle::deprecate_stop("0.4.1", "coef(simplify = 'must be TRUE')")
   }
 
   lower <- (1 - conf_level) / 2
@@ -68,29 +68,16 @@ coef_numeric_impl <- function(
     abort_chk("`estimate` must return a scalar")
   }
 
-  if (simplify) {
-    svalue <- if (directional_information) {
-      extras::directional_information(object)
-    } else {
-      extras::svalue(object)
-    }
-    return(tibble(
-      estimate = estimate,
-      lower = quantiles[1],
-      upper = quantiles[2],
-      svalue = svalue
-    ))
+  svalue <- if (directional_information) {
+    extras::directional_information(object)
+  } else {
+    extras::svalue(object)
   }
-  sd <- stats::sd(object)
-  zscore <- mean(object) / sd
-
   tibble(
     estimate = estimate,
-    sd = sd,
-    zscore = zscore,
     lower = quantiles[1],
     upper = quantiles[2],
-    pvalue = extras::pvalue(object)
+    svalue = svalue
   )
 }
 
@@ -162,10 +149,7 @@ coef.mcmc <- function(
   )
   object <- do.call(rbind, object)
   object$term <- term
-  colnames <- c("term", "estimate", "sd", "zscore", "lower", "upper", "pvalue")
-  if (simplify) {
-    colnames <- c("term", "estimate", "lower", "upper", "svalue")
-  }
+  colnames <- c("term", "estimate", "lower", "upper", "svalue")
   object <- object[colnames]
   object <- object[order(object$term), ]
   object

--- a/R/params.R
+++ b/R/params.R
@@ -26,7 +26,7 @@
 #' @param object The MCMC object to get the coefficients for
 #' @param conf_level A number specifying the confidence level. By default 0.95.
 #' @param estimate The function to use to calculate the estimate.
-#' @param simplify A flag specifying whether to return just the estimate, lower, upper and svalue.
+#' @param simplify `r lifecycle::badge("deprecated")` Must be `TRUE`.
 #' @param directional_information A flag specifying whether the svalue column
 #' should be calculated using [extras::directional_information()] instead of
 #' [extras::svalue()].

--- a/R/pars.R
+++ b/R/pars.R
@@ -25,7 +25,12 @@ pars.mcmcr <- function(x, scalar = NULL, terms = FALSE, ...) {
   chk_unused(...)
 
   if (!missing(terms)) {
-    deprecate_warn("0.2.1", "mcmcr::pars(terms =)", details = "If `terms = TRUE` use `term::pars_terms(as_term(x))` otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.", id = "pars_terms")
+    deprecate_warn(
+      "0.2.1",
+      "mcmcr::pars(terms =)",
+      details = "If `terms = TRUE` use `term::pars_terms(as_term(x))` otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.",
+      id = "pars_terms"
+    )
   }
   pars_impl(x, scalar, terms)
 }

--- a/R/rhat.R
+++ b/R/rhat.R
@@ -119,7 +119,7 @@ rhat.mcmcrs <- function(
   if (!bound) {
     return(rhat)
   }
-  lifecycle::deprecate_soft(
+  lifecycle::deprecate_warn(
     "0.6.1.9001",
     I("`rhat.mcmcrs(x, bound = TRUE)` returns scalar"),
     I("`rhat(x, bound = TRUE)$bound` for previous behaviour"),

--- a/man/coef.Rd
+++ b/man/coef.Rd
@@ -21,7 +21,7 @@
 
 \item{estimate}{The function to use to calculate the estimate.}
 
-\item{simplify}{A flag specifying whether to return just the estimate, lower, upper and svalue.}
+\item{simplify}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Must be \code{TRUE}.}
 
 \item{directional_information}{A flag specifying whether the svalue column
 should be calculated using \code{\link[extras:directional_information]{extras::directional_information()}} instead of

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -52,7 +52,7 @@ data frame versus a named list.}
 
 \item{estimate}{The function to use to calculate the estimate.}
 
-\item{simplify}{A flag specifying whether to return just the estimate, lower, upper and svalue.}
+\item{simplify}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Must be \code{TRUE}.}
 
 \item{directional_information}{A flag specifying whether the svalue column
 should be calculated using \code{\link[extras:directional_information]{extras::directional_information()}} instead of

--- a/tests/testthat/test-coef.R
+++ b/tests/testthat/test-coef.R
@@ -1,22 +1,12 @@
-test_that("coef.mcmc", {
-  rlang::local_options(lifecycle_verbosity = "quiet")
-
-  coef_mcmc.list <- coef(as.mcmc.list(mcmcr_example), simplify = FALSE)
-  expect_identical(
-    colnames(coef_mcmc.list),
-    c("term", "estimate", "sd", "zscore", "lower", "upper", "pvalue")
+test_that("coef simplify = FALSE is defunct", {
+  lifecycle::expect_defunct(
+    coef(as.mcmc.list(mcmcr_example), simplify = FALSE)
   )
-  expect_identical(
-    coef_mcmc.list$term,
-    sort(as_term(c(
-      "alpha[1]",
-      "alpha[2]",
-      "beta[1,1]",
-      "beta[2,1]",
-      "beta[1,2]",
-      "beta[2,2]",
-      "sigma"
-    )))
+  lifecycle::expect_defunct(
+    coef(mcmcr_example, simplify = FALSE)
+  )
+  lifecycle::expect_defunct(
+    coef(as.numeric(1:10), simplify = FALSE)
   )
 })
 


### PR DESCRIPTION
Closes #65

Two deprecation escalations following on from #72:

- `coef(simplify = FALSE)` moves from `deprecate_warn()` (at warn since 0.4.1, shipped to CRAN in 0.5.0, Feb 2021) to `deprecate_stop()`. The now-unreachable non-simplified branch (`sd`, `zscore`, `pvalue` columns) is deleted from `coef_numeric_impl()` and `coef.mcmc()`, and the `simplify` parameter documentation gets a deprecated badge. The first `coef` test, which exercised the non-simplified output, is replaced with `lifecycle::expect_defunct()` tests across methods.
- The `rhat.mcmcrs(bound = TRUE)` behaviour-change signal moves from `deprecate_soft()` to `deprecate_warn()`. It was introduced in 0.6.1.9001 and shipped to CRAN in 0.6.2 (January 2025), so indirect users are now warned too.

Also includes air re-wrapping of the two long `deprecate_warn()` calls in `pars.R` from #72 (the air formatting PR branched before #72 merged).

Verified locally: `coef(mcmcr_example, simplify = FALSE)` errors with "The `simplify` argument of `coef()` must be TRUE as of mcmcr 0.4.1", and `rhat(mcmcrs(...), bound = TRUE)` warns when called indirectly. Full test suite shows no new failures (the 7 pre-existing failures are dev-chk error-message text changes, same as on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)