### PR TITLE
Restore deprecation escalations from #72 reverted by air formatting PR

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -40,7 +40,7 @@ check_mcmcr <- function(
   x_name = substitute(x),
   error = TRUE
 ) {
-  lifecycle::deprecate_soft("v0.2.1", "check_mcmcr()", "chk_mcmcr()")
+  lifecycle::deprecate_warn("0.2.1", "check_mcmcr()", "chk_mcmcr()")
   x_name <- deparse_backtick_chk(x_name)
   chk_flag(sorted)
   chk_string(x_name)

--- a/R/pars.R
+++ b/R/pars.R
@@ -46,10 +46,10 @@ pars.mcmcrs <- function(x, scalar = NULL, terms = FALSE, ...) {
   chk_unused(...)
 
   if (!missing(terms)) {
-    deprecate_soft(
+    deprecate_warn(
       "0.2.1",
       "mcmcr::pars(terms =)",
-      details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.",
+      details = "If `terms = TRUE` use `term::pars_terms(as_term(x))` otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.",
       id = "pars_terms"
     )
   }

--- a/R/subset.R
+++ b/R/subset.R
@@ -24,7 +24,7 @@ subset.mcmcarray <- function(
   ...
 ) {
   if (!missing(iterations)) {
-    deprecate_soft(
+    deprecate_warn(
       "0.2.1",
       "subset(iterations = )",
       "subset(iters = )",
@@ -66,7 +66,7 @@ subset.mcmcr <- function(
   ...
 ) {
   if (!missing(iterations)) {
-    deprecate_soft(
+    deprecate_warn(
       "0.2.1",
       "subset(iterations = )",
       "subset(iters = )",
@@ -75,7 +75,7 @@ subset.mcmcr <- function(
     iters <- iterations
   }
   if (!missing(parameters)) {
-    deprecate_soft(
+    deprecate_warn(
       "0.2.1",
       "subset(parameters = )",
       "subset(pars = )",
@@ -111,7 +111,7 @@ subset.mcmcrs <- function(
   ...
 ) {
   if (!missing(iterations)) {
-    deprecate_soft(
+    deprecate_warn(
       "0.2.1",
       "subset(iterations = )",
       "subset(iters = )",
@@ -120,7 +120,7 @@ subset.mcmcrs <- function(
     iters <- iterations
   }
   if (!missing(parameters)) {
-    deprecate_soft(
+    deprecate_warn(
       "0.2.1",
       "subset(parameters = )",
       "subset(pars = )",

--- a/tests/testthat/test-aaa-deprecated.R
+++ b/tests/testthat/test-aaa-deprecated.R
@@ -27,6 +27,16 @@ test_that("check_mcmcarray", {
   )
 })
 
+test_that("check_mcmcr is deprecated", {
+  lifecycle::expect_deprecated(
+    lifecycle::expect_deprecated(
+      check_mcmcr(mcmcr::mcmcr_example),
+      "check_mcmcr"
+    ),
+    "check_mcmcarray"
+  )
+})
+
 test_that("check_mcmcr", {
   rlang::local_options(lifecycle_verbosity = "quiet")
 

--- a/tests/testthat/test-pars.R
+++ b/tests/testthat/test-pars.R
@@ -17,3 +17,9 @@ test_that("pars.mcmcrs", {
   pars(mcmcrs) <- c("alpha1", "alpha2", "alpha3")
   expect_identical(pars(mcmcrs), c("alpha1", "alpha2", "alpha3"))
 })
+
+test_that("pars terms argument is deprecated", {
+  lifecycle::expect_deprecated(pars(mcmcr::mcmcr_example, terms = FALSE))
+  mcmcrs <- mcmcrs(mcmcr::mcmcr_example, mcmcr::mcmcr_example)
+  lifecycle::expect_deprecated(pars(mcmcrs, terms = FALSE))
+})

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -19,6 +19,21 @@ test_that("subset.mcmcrs", {
   expect_identical(nterms(subset(mcmcrs, pars = "beta")), 4L)
 })
 
+test_that("subset iterations and parameters arguments are deprecated", {
+  lifecycle::expect_deprecated(subset(mcmcr_example$beta, iterations = 1:10))
+  lifecycle::expect_deprecated(subset(mcmcr_example, iterations = 1:10))
+  lifecycle::expect_deprecated(subset(mcmcr_example, parameters = "beta"))
+  mcmcrs <- mcmcrs(mcmcr::mcmcr_example, mcmcr::mcmcr_example)
+  lifecycle::expect_deprecated(subset(mcmcrs, iterations = 1:10))
+  lifecycle::expect_deprecated(subset(mcmcrs, parameters = "beta"))
+
+  rlang::local_options(lifecycle_verbosity = "quiet")
+  expect_identical(
+    subset(mcmcr_example, iterations = 1:10, parameters = "beta"),
+    subset(mcmcr_example, iters = 1:10, pars = "beta")
+  )
+})
+
 test_that("subset.mcmc.list", {
   expect_identical(
     pars(subset(as.mcmc.list(mcmcr_example), pars = "beta")),


### PR DESCRIPTION
Closes #75

PR #73 (air formatting) branched before #72 merged and its whole-file reformat reverted several of #72's deprecation escalations. This re-applies them on top of the air formatting:

- `R/subset.R`: all five `iterations`/`parameters` deprecations back to `deprecate_warn()`
- `R/pars.R`: the `pars.mcmcrs()` `terms =` deprecation back to `deprecate_warn()`, with the details typos re-fixed (`term::` not `terms::`, closing backtick restored)
- `R/check.R`: `check_mcmcr()` back to `deprecate_warn("0.2.1", ...)`, dropping the nonstandard `"v0.2.1"` when string

The revert was also a runtime bug: `deprecate_soft` is no longer imported (since #72 changed the `@importFrom` to `deprecate_warn`), so the bare reverted calls in `subset.R` and `pars.R` errored with "could not find function" whenever the deprecated arguments were used. No tests exercised those arguments, which is why CI stayed green.

New regression tests cover the deprecated arguments so a future revert is caught: `lifecycle::expect_deprecated()` for `subset(iterations = )` / `subset(parameters = )` across mcmcarray/mcmcr/mcmcrs (plus equivalence with `iters`/`pars`), `pars(terms = )` on mcmcr/mcmcrs, and `check_mcmcr()`.

Full test suite run locally: 446 passing, 0 new failures (the 7 pre-existing errors are the dev-chk error-message text changes, same as on main). `air format --check` passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)