### PR TITLE
Update test expectations for chk 0.11.0

### DIFF
--- a/tests/testthat/test-aaa-deprecated.R
+++ b/tests/testthat/test-aaa-deprecated.R
@@ -7,7 +7,7 @@ test_that("check_mcmcarray", {
   )
   expect_error(
     check_mcmcarray(1),
-    "^`1` must inherit from S3 class 'mcmcarray'[.]$",
+    "^`1` must inherit from S3 class 'mcmcarray'",
     class = "chk_error"
   )
 
@@ -47,14 +47,14 @@ test_that("check_mcmcr", {
   )
   expect_error(
     check_mcmcr(1),
-    "^`1` must inherit from S3 class 'mcmcr'[.]$",
+    "^`1` must inherit from S3 class 'mcmcr'",
     class = "chk_error"
   )
 
   y <- set_class(list(x = 1), "mcmcr")
   expect_error(
     check_mcmcr(y),
-    "must inherit from S3 class 'mcmcarray'[.]$",
+    "must inherit from S3 class 'mcmcarray'",
     class = "chk_error"
   )
 

--- a/tests/testthat/test-bind-chains.R
+++ b/tests/testthat/test-bind-chains.R
@@ -25,7 +25,7 @@ test_that("bind_chains.mcarray", {
 
   expect_error(
     bind_chains(as.mcarray(mcmcr_example$beta), mcmcr_example),
-    "^`x2` must inherit from S3 class 'mcarray'[.]$",
+    "^`x2` must inherit from S3 class 'mcarray'",
     class = "chk_error"
   )
 
@@ -53,7 +53,7 @@ test_that("bind_chains.mcmc", {
       as.mcmc(collapse_chains(mcmcr_example)),
       mcmcr_example
     )),
-    "^`x2` must inherit from S3 class 'mcmc'[.]$",
+    "^`x2` must inherit from S3 class 'mcmc'",
     class = "chk_error"
   )
 

--- a/tests/testthat/test-chk.R
+++ b/tests/testthat/test-chk.R
@@ -3,7 +3,7 @@ test_that("chk_mcmcarray", {
   expect_invisible(chk_mcmcarray(as.mcmcarray(1)))
   expect_error(
     chk_mcmcarray(1),
-    "^`1` must inherit from S3 class 'mcmcarray'[.]$",
+    "^`1` must inherit from S3 class 'mcmcarray'",
     class = "chk_error"
   )
   x <- 1
@@ -27,7 +27,7 @@ test_that("chk_mcmcr", {
   expect_invisible(chk_mcmcr(as.mcmcr(list(x = 1))))
   expect_error(
     chk_mcmcr(1),
-    "^`1` must inherit from S3 class 'mcmcr'[.]$",
+    "^`1` must inherit from S3 class 'mcmcr'",
     class = "chk_error"
   )
   x <- list(x = 1)
@@ -35,7 +35,7 @@ test_that("chk_mcmcr", {
 
   expect_error(
     chk_mcmcr(x),
-    "^All elements of `x` must inherit from S3 class 'mcmcarray'[.]$",
+    "^All elements of `x` must inherit from S3 class 'mcmcarray'",
     class = "chk_error"
   )
 })
@@ -45,7 +45,7 @@ test_that("chk_mcmcrs", {
   expect_invisible(chk_mcmcr(as.mcmcr(list(x = 1))))
   expect_error(
     chk_mcmcr(1),
-    "^`1` must inherit from S3 class 'mcmcr'[.]$",
+    "^`1` must inherit from S3 class 'mcmcr'",
     class = "chk_error"
   )
   x <- list(x = 1)
@@ -53,7 +53,7 @@ test_that("chk_mcmcrs", {
 
   expect_error(
     chk_mcmcr(x),
-    "^All elements of `x` must inherit from S3 class 'mcmcarray'[.]$",
+    "^All elements of `x` must inherit from S3 class 'mcmcarray'",
     class = "chk_error"
   )
 })


### PR DESCRIPTION
chk 0.11.0 (about to be submitted to CRAN) improves `chk_s3_class()` error messages to also state the object's actual class, e.g. `"\`x\` must inherit from S3 class 'mcmcr', not S3 class 'numeric'."` instead of ending after the expected class name. This broke 10 test expectations in mcmcr that anchored the expected regexp with a trailing `[.]$`.

This PR drops the trailing end-of-string anchor from the affected `expect_error()` regexps in `test-aaa-deprecated.R`, `test-bind-chains.R` and `test-chk.R` so they match the message prefix under both versions. No code in `R/` is changed.

Verified the full test suite passes with:

- CRAN chk 0.10.0: `[ FAIL 0 | WARN 2 | SKIP 0 | PASS 472 ]`
- dev chk 0.11.0: `[ FAIL 0 | WARN 2 | SKIP 0 | PASS 472 ]`

(The 2 warnings are pre-existing nlist `tidy()` deprecation warnings unrelated to this change.) The fix is robust to both chk versions, so it can be merged before chk 0.11.0 reaches CRAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)