### PR TITLE
Add directional_information argument to tidy.mcmcr()

### DIFF
--- a/R/coef.R
+++ b/R/coef.R
@@ -15,12 +15,13 @@
 NULL
 
 warn_default_directional_information <- function(
+  fun = "coef",
   env = parent.frame(),
   user_env = parent.frame(2)
 ) {
   lifecycle::deprecate_soft(
     "0.7.0",
-    "coef(directional_information = 'should be explicitly set')",
+    paste0(fun, "(directional_information = 'should be explicitly set')"),
     details = paste(
       "The default value of `directional_information` will change from",
       "`FALSE` to `TRUE` in a future release."

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -2,9 +2,22 @@
 generics::tidy
 
 #' @inheritParams nlist::tidy.nlist
+#' @inheritParams params
 #'
 #' @export
-tidy.mcmcr <- function(x, simplify = FALSE, ...) {
+tidy.mcmcr <- function(
+  x,
+  simplify = FALSE,
+  directional_information = FALSE,
+  ...
+) {
   chk_unused(...)
-  tidy(as_mcmc_list(x), simplify = simplify)
+  if (missing(directional_information)) {
+    warn_default_directional_information("tidy")
+  }
+  tidy(
+    as_mcmc_list(x),
+    simplify = simplify,
+    directional_information = directional_information
+  )
 }

--- a/tests/testthat/test-coef.R
+++ b/tests/testthat/test-coef.R
@@ -121,12 +121,12 @@ test_that("coef directional_information consistent across classes", {
 })
 
 test_that("coef directional_information values", {
-  # all values above the threshold: information capped at a bit per sample
+  # all values above the threshold: information capped at log2(n) bits
   x <- as.numeric(1:100)
-  expect_identical(coef(x, directional_information = TRUE)$svalue, 100)
+  expect_equal(coef(x, directional_information = TRUE)$svalue, 6.64385619)
 
   # all values below the threshold: side = "median" uses the left side
-  expect_identical(coef(-x, directional_information = TRUE)$svalue, 100)
+  expect_equal(coef(-x, directional_information = TRUE)$svalue, 6.64385619)
 
   # equal numbers of values on each side: no directional information
   expect_identical(

--- a/tests/testthat/test-tidy.R
+++ b/tests/testthat/test-tidy.R
@@ -1,7 +1,26 @@
 test_that("tidy.mcmcr", {
   x <- subset(mcmcr::mcmcr_example, iters = 1:2)
   expect_identical(
-    tidy(x, simplify = TRUE),
-    tidy(nlist::as_mcmc_list(x), simplify = TRUE)
+    tidy(x, simplify = TRUE, directional_information = FALSE),
+    tidy(
+      nlist::as_mcmc_list(x),
+      simplify = TRUE,
+      directional_information = FALSE
+    )
   )
+  expect_identical(
+    tidy(x, simplify = TRUE, directional_information = TRUE),
+    tidy(
+      nlist::as_mcmc_list(x),
+      simplify = TRUE,
+      directional_information = TRUE
+    )
+  )
+})
+
+test_that("tidy soft-deprecates unset directional_information", {
+  x <- subset(mcmcr::mcmcr_example, iters = 1:2)
+  lifecycle::expect_deprecated(tidy(x, simplify = TRUE))
+  expect_no_warning(tidy(x, simplify = TRUE, directional_information = FALSE))
+  expect_no_warning(tidy(x, simplify = TRUE, directional_information = TRUE))
 })


### PR DESCRIPTION
Related to #79.

## Summary

The dev versions of extras and nlist changed how directional information svalues are computed: `extras::directional_information()` now caps the svalue at log2(n) bits and the nlist `tidy()` methods gained a `directional_information` argument that soft-deprecates when unset. `tidy.mcmcr()` did not expose the argument, so it always delegated with the old `FALSE` behaviour and triggered nlist's deprecation warning from inside mcmcr with no way for users to silence it.

- `tidy.mcmcr()` gains `directional_information = FALSE`, passed through to `nlist::tidy()`, with the same soft-deprecation warning when unset as the `coef()` methods (default flips to `TRUE` in a future release).
- `warn_default_directional_information()` is parameterized with a `fun` argument so the same helper serves both `coef()` and `tidy()` with distinct lifecycle messages.
- Test expectations updated for the new extras log2(n) cap and a deprecation regression test added for `tidy()`.

## Verification

```r
library(mcmcr)
x <- subset(mcmcr_example, iters = 1:2)
tidy(x, simplify = TRUE, directional_information = TRUE)
# matches tidy(nlist::as_mcmc_list(x), simplify = TRUE, directional_information = TRUE)
tidy(x, simplify = TRUE) # soft-deprecation warning to set the argument
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)