### PR TITLE
Remove re-exports of term's defunct parameters functions and ignore .claude

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^README\.Rmd$
 ^[.]?air[.]toml$
 ^\.vscode$
+^\.claude$

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -155,7 +155,6 @@ S3method(tidy,mcmcr)
 S3method(zero,mcarray)
 S3method(zero,mcmcarray)
 S3method(zero,mcmcr)
-export("parameters<-")
 export("pars<-")
 export(as.mcarray)
 export(as.mcmc)
@@ -206,7 +205,6 @@ export(nlists)
 export(npars)
 export(npdims)
 export(nterms)
-export(parameters)
 export(pars)
 export(pdims)
 export(pvalue)
@@ -261,11 +259,9 @@ importFrom(stats,
   terms
 )
 importFrom(term,
-  "parameters<-",
   as.term,
   as_term,
-  complete_terms,
-  parameters
+  complete_terms
 )
 importFrom(tibble,tibble)
 importFrom(universals,

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -1,5 +1,0 @@
-#' @export
-term::parameters
-
-#' @export
-term::`parameters<-`

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -3,8 +3,8 @@
 %   R/as-nlists.R, R/as-term.R, R/bind-chains.R, R/bind-iterations.R,
 %   R/collapse-chains.R, R/converged.R, R/esr.R, R/estimates.R, R/export.R,
 %   R/fill-all.R, R/fill_na.R, R/nchains.R, R/niters.R, R/npars.R, R/npdims.R,
-%   R/nterms.R, R/parameters.R, R/pars.R, R/pdims.R, R/rhat.R, R/set-pars.R,
-%   R/split-chains.R, R/thin.R, R/tidy.R
+%   R/nterms.R, R/pars.R, R/pdims.R, R/rhat.R, R/set-pars.R, R/split-chains.R,
+%   R/thin.R, R/tidy.R
 \docType{import}
 \name{reexports}
 \alias{reexports}
@@ -37,8 +37,6 @@
 \alias{npars}
 \alias{npdims}
 \alias{nterms}
-\alias{parameters}
-\alias{parameters<-}
 \alias{pars}
 \alias{pdims}
 \alias{rhat}
@@ -64,7 +62,7 @@ below to see their documentation.
 
   \item{stats}{\code{\link[stats:median]{median()}}}
 
-  \item{term}{\code{\link[term:as_term]{as_term()}}, \code{\link[term:as.term]{as.term()}}, \code{\link[term:complete_terms]{complete_terms()}}, \code{\link[term:parameters]{parameters()}}, \code{\link[term:parameters<-]{parameters<-()}}}
+  \item{term}{\code{\link[term:as_term]{as_term()}}, \code{\link[term:as.term]{as.term()}}, \code{\link[term:complete_terms]{complete_terms()}}}
 
   \item{universals}{\code{\link[universals:bind_chains]{bind_chains()}}, \code{\link[universals:bind_iterations]{bind_iterations()}}, \code{\link[universals:collapse_chains]{collapse_chains()}}, \code{\link[universals:converged]{converged()}}, \code{\link[universals:dims]{dims()}}, \code{\link[universals:esr]{esr()}}, \code{\link[universals:estimates]{estimates()}}, \code{\link[universals:nchains]{nchains()}}, \code{\link[universals:niters]{niters()}}, \code{\link[universals:npars]{npars()}}, \code{\link[universals:npdims]{npdims()}}, \code{\link[universals:nterms]{nterms()}}, \code{\link[universals:pars]{pars()}}, \code{\link[universals:pars<-]{pars<-()}}, \code{\link[universals:pdims]{pdims()}}, \code{\link[universals:rhat]{rhat()}}, \code{\link[universals:set_pars]{set_pars()}}, \code{\link[universals:split_chains]{split_chains()}}}
 }}


### PR DESCRIPTION
`term::parameters()` and `` term::`parameters<-`() `` become defunct in term 0.4.0 (poissonconsulting/term#103). mcmcr re-exports both, so as of that release mcmcr exports two functions that can only error.

- Delete `R/parameters.R`, dropping `parameters()` and `parameters<-()` from mcmcr's exports and from the `term` `importFrom` block
- Regenerate `NAMESPACE` and `man/reexports.Rd`
- Add `^\.claude$` to `.Rbuildignore`, clearing the "checking for hidden files and directories" NOTE (term already carries this entry)

The tests that exercised the re-exports were already removed in #83, so nothing else changes.

**Breaking change:** `mcmcr::parameters()` and `mcmcr::parameters<-()` are no longer exported. Use `pars()` and `pars<-()`. This warrants the 0.7.0 bump that `coef(directional_information =)` is already targeting.

## Verification

Checked against the term 0.4.0 development version (0.3.7.9019) installed into a scratch library:

- `devtools::test()` on mcmcr main before this change: all tests pass, so this is cleanup rather than a fix for a broken revdep
- `devtools::check()` with these changes: `Status: OK`
- `pkgbuild::build()` confirms `.claude` no longer appears in the tarball
- No reverse dependency calls `mcmcr::parameters()`: checked mcmcderive, nlist, mbr, embr, smbr2 and jmbr; every hit is a local variable or a package's own `subset(parameters =)` argument

CI on this branch is red for a reason that predates it: `tidy.mcmcr()` forwards `directional_information` to `nlist::tidy.mcmc.list()`, which only accepts it in the unreleased nlist 0.5.0. See the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)