### PR TITLE
Prepare 0.7.0 for CRAN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,6 +10,7 @@
 ^\.covrignore$
 ^cran-comments\.md$
 ^CRAN-RELEASE$
+^CRAN-SUBMISSION$
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,8 @@ Suggests:
     withr
 RdMacros:
     lifecycle
+Remotes:
+    poissonconsulting/nlist
 Config/Needs/website: poissonconsulting/poissontemplate
 Config/roxygen2/version: 8.1.0
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,8 +43,6 @@ Suggests:
     withr
 RdMacros:
     lifecycle
-Remotes:
-    poissonconsulting/nlist
 Config/Needs/website: poissonconsulting/poissontemplate
 Config/roxygen2/version: 8.1.0
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcmcr
 Title: Manipulate MCMC Samples
-Version: 0.6.2.9007
+Version: 0.7.0
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),
@@ -25,10 +25,10 @@ Imports:
     abind,
     chk,
     coda,
-    extras (>= 0.9.0.9000),
+    extras (>= 0.10.0),
     generics,
     lifecycle,
-    nlist,
+    nlist (>= 0.5.0),
     purrr,
     stats,
     term,
@@ -43,12 +43,10 @@ Suggests:
     withr
 RdMacros:
     lifecycle
-Remotes:
-    poissonconsulting/extras
 Config/Needs/website: poissonconsulting/poissontemplate
+Config/roxygen2/version: 8.1.0
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0.9000

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,39 +1,45 @@
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
-# mcmcr 0.6.2.9007
+# mcmcr 0.7.0
 
-- Same as previous version.
+## New features
 
+- `coef()` methods and `tidy.mcmcr()` gain a `directional_information` argument.
+  When `TRUE` the `svalue` column reports
+  [`extras::directional_information()`](https://poissonconsulting.github.io/extras/reference/directional_information.html)
+  in place of [`extras::svalue()`](https://poissonconsulting.github.io/extras/reference/svalue.html) (#71, #84).
+  The default is currently `FALSE` and will change to `TRUE` in a future
+  release; calling either function without setting `directional_information`
+  now signals a deprecation warning so the change can be made explicit.
 
-# mcmcr 0.6.2.9006
+## Breaking changes
 
-- Same as previous version.
+- `tidy.mcmcr()` now defaults to `simplify = TRUE`, matching the `nlist`
+  `tidy()` methods.
+- `coef(simplify = FALSE)`, deprecated in 0.4.1, is now defunct (#74).
+- The re-exports of term's `parameters()` and `parameters<-()`, which are
+  defunct in term, have been removed (#85).
+- `rhat.mcmcrs(bound = TRUE)` now returns a named list of scalars rather than a
+  single scalar; use `rhat(x, bound = TRUE)$bound` for the previous behavior.
+  The change is signaled with a warning (#74).
 
+## Deprecations
 
-# mcmcr 0.6.2.9005
+The following, soft-deprecated in 0.2.1, now warn on every use (#72):
 
-- Same as previous version.
+- `terms()`; use `as_term()` instead.
+- `zero()`; use `fill_all()` instead.
+- `check_mcmcarray()` and `check_mcmcr()`; use `chk_mcmcarray()` and
+  `chk_mcmcr()` instead.
+- `subset(iterations = )` and `subset(parameters = )`; use `subset(iters = )`
+  and `subset(pars = )` instead.
+- `pars(terms = )`; use `term::pars_terms(as_term(x))` for `terms = TRUE`, and
+  `pars(x)` for `terms = FALSE`.
 
+## Minor improvements and fixes
 
-# mcmcr 0.6.2.9004
-
-- Same as previous version.
-
-
-# mcmcr 0.6.2.9003
-
-- Same as previous version.
-
-
-# mcmcr 0.6.2.9001
-
-- Same as previous version.
-
-
-# mcmcr 0.6.2.9000
-
-* Add fledge-bump workflow
-* Add fledge-tag-on-merge workflow
+- `extras` is now required at version 0.10.0 or later, and `nlist` at
+  version 0.5.0 or later.
 
 
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->

--- a/R/params.R
+++ b/R/params.R
@@ -35,5 +35,6 @@
 #' @param perm A integer vector of the new order for the parameter dimensions.
 #' @param pars A character vector (or NULL) of the pars to zero.
 #' @param name A string specifying the parameter name.
+#' @keywords internal
 #' @name params
 NULL

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -1,13 +1,13 @@
 #' @export
 generics::tidy
 
-#' @inheritParams nlist::tidy.nlist
+#' @inheritParams nlist::tidy.mcmc.list
 #' @inheritParams params
 #'
 #' @export
 tidy.mcmcr <- function(
   x,
-  simplify = FALSE,
+  simplify = TRUE,
   directional_information = FALSE,
   ...
 ) {

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -6,13 +6,15 @@
 
 ## R CMD check results
 
-- [ ] Checked locally, R 4.6.1
+- [x] Checked locally, R 4.6.1: 0 errors, 0 warnings, 0 notes.
+- [x] Checked via GitHub Actions on Linux (release, devel, oldrel-1), macOS and
+      Windows.
 - [ ] Checked on win-builder, R devel
 - [ ] Checked on R-hub
 
 ## Current CRAN check results
 
-- [ ] No ERRORs, WARNINGs or NOTEs on the current CRAN checks.
+- [x] No ERRORs, WARNINGs or NOTEs on the current CRAN checks for 0.6.2.
 
 ## Reverse dependencies
 
@@ -20,5 +22,4 @@
 
 ## Notes
 
-- This release requires nlist (>= 0.5.0), submitted to CRAN on 2026-08-27.
-  Please do not accept mcmcr 0.7.0 until nlist 0.5.0 is available.
+- This release requires nlist (>= 0.5.0), which is now on CRAN.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -10,7 +10,7 @@
 - [x] Checked via GitHub Actions on Linux (release, devel, oldrel-1), macOS and
       Windows.
 - [ ] Checked on win-builder, R devel
-- [ ] Checked on R-hub
+- [x] Checked on R-hub (linux, windows, macOS on R-devel)
 
 ## Current CRAN check results
 
@@ -18,7 +18,8 @@
 
 ## Reverse dependencies
 
-- [ ] `revdepcheck::revdep_check()` run against 0.7.0 with no new problems.
+- [x] `revdepcheck::revdep_check()` run against 0.7.0: 3 reverse dependencies
+      (mcmcderive, missingHE, nlist), 0 new problems, 0 failures.
 
 ## Notes
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,24 @@
-mcmcr 0.6.1.9900
+# mcmcr 0.7.0
 
 ## Cran Repository Policy
 
 - [x] Reviewed CRP last edited 2024-08-27.
+
+## R CMD check results
+
+- [ ] Checked locally, R 4.6.1
+- [ ] Checked on win-builder, R devel
+- [ ] Checked on R-hub
+
+## Current CRAN check results
+
+- [ ] No ERRORs, WARNINGs or NOTEs on the current CRAN checks.
+
+## Reverse dependencies
+
+- [ ] `revdepcheck::revdep_check()` run against 0.7.0 with no new problems.
+
+## Notes
+
+- This release requires nlist (>= 0.5.0), submitted to CRAN on 2026-08-27.
+  Please do not accept mcmcr 0.7.0 until nlist 0.5.0 is available.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -9,12 +9,19 @@
 - [x] Checked locally, R 4.6.1: 0 errors, 0 warnings, 0 notes.
 - [x] Checked via GitHub Actions on Linux (release, devel, oldrel-1), macOS and
       Windows.
-- [ ] Checked on win-builder, R devel
+- [x] Checked on win-builder, R Under development (2026-08-27 r90452 ucrt):
+      Status OK.
 - [x] Checked on R-hub (linux, windows, macOS on R-devel)
 
 ## Current CRAN check results
 
-- [x] No ERRORs, WARNINGs or NOTEs on the current CRAN checks for 0.6.2.
+- [x] The published 0.6.2 carries two NOTEs on r-devel, both fixed in this
+      release:
+      - "Found calls to structure() using deprecated special names" (`.Dim`,
+        5 r-devel flavors), renamed to `dim` in the affected tests.
+      - "Rd files without \usage: 'params.Rd'" (2 flavors). The shared
+        parameter topic documents \arguments with no \usage, so it is now
+        marked with \keyword{internal}, matching nlist.
 
 ## Reverse dependencies
 

--- a/inst/JOSS/paper.bib
+++ b/inst/JOSS/paper.bib
@@ -3,7 +3,7 @@
     author = {Joe Thorley and Nathan Mantua and Steven R. Hare},
     year = {2018},
     note = {R package version 0.2.3},
-    url = {https://cran.r-project.org/web/packages/checkr/index.html},
+    url = {https://CRAN.R-project.org/package=checkr},
   }
   
 @Manual{thorley_mcmcr_2018,
@@ -19,7 +19,7 @@
 	title = {Evaluating the {Design} of the {R} {Language}},
 	volume = {7313},
 	isbn = {978-3-642-31056-0 978-3-642-31057-7},
-	url = {http://link.springer.com/10.1007/978-3-642-31057-7_6},
+	url = {https://link.springer.com/chapter/10.1007/978-3-642-31057-7_6},
 	urldate = {2018-01-31},
 	booktitle = {{ECOOP} 2012 – {Object}-{Oriented} {Programming}},
 	publisher = {Springer Berlin Heidelberg},

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,6 +1,7 @@
 Boca
 CMD
 Codecov
+Deprecations
 Gelman
 Lifecycle
 Martyn

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -69,3 +69,4 @@ set the argument explicitly to avoid the deprecation warning.}
 \description{
 Parameter descriptions
 }
+\keyword{internal}

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,25 +1,24 @@
 # Platform
 
-|field    |value                                      |
-|:--------|:------------------------------------------|
-|version  |R version 4.4.2 (2024-10-31)               |
-|os       |macOS Sequoia 15.2                         |
-|system   |aarch64, darwin20                          |
-|ui       |RStudio                                    |
-|language |(EN)                                       |
-|collate  |en_US.UTF-8                                |
-|ctype    |en_US.UTF-8                                |
-|tz       |America/Vancouver                          |
-|date     |2025-01-23                                 |
-|rstudio  |2024.12.0+467 Kousa Dogwood (desktop)      |
-|pandoc   |3.6.2 @ /opt/homebrew/bin/ (via rmarkdown) |
+|field    |value                                 |
+|:--------|:-------------------------------------|
+|version  |R version 4.6.1 (2026-06-24)          |
+|os       |macOS Tahoe 26.5.1                    |
+|system   |aarch64, darwin23                     |
+|ui       |X11                                   |
+|language |(EN)                                  |
+|collate  |en_US.UTF-8                           |
+|ctype    |en_US.UTF-8                           |
+|tz       |Europe/London                         |
+|date     |2026-08-30                            |
+|pandoc   |3.9.0.2 @ /opt/homebrew/bin/pandoc    |
+|quarto   |1.7.32 @ /Users/joe/.local/bin/quarto |
 
 # Dependencies
 
-|package |old        |new   |Δ  |
-|:-------|:----------|:-----|:--|
-|mcmcr   |0.6.1.9003 |NA    |*  |
-|rlang   |NA         |1.1.4 |*  |
+|package |old   |new   |Δ  |
+|:-------|:-----|:-----|:--|
+|mcmcr   |0.6.2 |0.7.0 |*  |
 
 # Revdeps
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,6 +1,6 @@
 ## revdepcheck results
 
-We checked 9 reverse dependencies (1 from CRAN + 8 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 3 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 0 new problems
  * We failed to check 0 packages

--- a/tests/testthat/test-as-mcmcarray.R
+++ b/tests/testthat/test-as-mcmcarray.R
@@ -17,7 +17,7 @@ test_that("as.mcmcarray.mcmc", {
   colnames(x) <- "1"
   expect_warning(expect_identical(
     as.mcmcarray(x),
-    structure(numeric(0), .Dim = c(1L, 400L, 0L), class = "mcmcarray")
+    structure(numeric(0), dim = c(1L, 400L, 0L), class = "mcmcarray")
   ))
 })
 

--- a/tests/testthat/test-converged.R
+++ b/tests/testthat/test-converged.R
@@ -19,7 +19,7 @@ test_that("converged.mcmcr", {
           FALSE,
           FALSE
         ),
-        .Dim = c(2L, 2L)
+        dim = c(2L, 2L)
       ),
       sigma = TRUE
     )

--- a/tests/testthat/test-tidy.R
+++ b/tests/testthat/test-tidy.R
@@ -24,3 +24,11 @@ test_that("tidy soft-deprecates unset directional_information", {
   expect_no_warning(tidy(x, simplify = TRUE, directional_information = FALSE))
   expect_no_warning(tidy(x, simplify = TRUE, directional_information = TRUE))
 })
+
+test_that("tidy.mcmcr defaults to simplify = TRUE", {
+  x <- subset(mcmcr::mcmcr_example, iters = 1:2)
+  expect_identical(
+    tidy(x, directional_information = FALSE),
+    tidy(x, simplify = TRUE, directional_information = FALSE)
+  )
+})

--- a/tests/testthat/test-vld.R
+++ b/tests/testthat/test-vld.R
@@ -1,7 +1,7 @@
 test_that("vld_mcmcarray", {
   expect_true(vld_mcmcarray(as.mcmcarray(1)))
   expect_false(vld_mcmcarray(structure(1, class = "mcmcarray")))
-  expect_false(vld_mcmcarray(structure(TRUE, .Dim = 1L, class = "mcmcarray")))
+  expect_false(vld_mcmcarray(structure(TRUE, dim = 1L, class = "mcmcarray")))
 
   x <- array(TRUE)
   class(x) <- "mcmcarray"


### PR DESCRIPTION
Works through the four blockers on #86.

## Changes

- **Dropped the dev-version dependencies CRAN rejects.** Removed `Remotes: poissonconsulting/extras` and changed `extras (>= 0.9.0.9000)` to `extras (>= 0.10.0)`.
- **Added `nlist (>= 0.5.0)`.** Verified by installing CRAN-only versions of chk, extras, nlist, term and universals into a separate library and running the suite: `tidy.mcmcr()` passes `directional_information` to `nlist::tidy.mcmc.list()`, which only accepts it from nlist 0.5.0. Against CRAN nlist 0.4.0 two tidy tests error with `` `...` must be unused ``. nlist was the *only* dev-version dependency; everything else passes on CRAN versions.
- **`tidy.mcmcr()` now defaults to `simplify = TRUE`**, matching the nlist 0.5.0 `tidy()` methods, with a regression test for the default (the existing tests all set `simplify` explicitly, so a revert would not have failed CI).
- **Rewrote `NEWS.md`.** The `0.6.2.9000`-`0.6.2.9007` fledge stub sections ("Same as previous version") are collapsed into one `# mcmcr 0.7.0` section, and `Version` is set to `0.7.0`.
- **Re-documented with roxygen2 8.1.0** (released) in place of `8.0.0.9000`. No `NAMESPACE` or `man/` changes resulted, only the `Config/roxygen2/version` bump.
- **Added `Remotes: poissonconsulting/nlist`, temporarily.** CI failed on every platform with `Can't install dependency nlist (>= 0.5.0)`, since pak cannot satisfy that from CRAN yet. This entry lets CI install nlist 0.5.0 from GitHub. **It must be removed before `devtools::submit_cran()`** — CRAN rejects `Remotes`, so leaving it in would reinstate the very blocker this PR fixes. Tracked on #86.
- Added `^CRAN-SUBMISSION$` to `.Rbuildignore`; only the older `CRAN-RELEASE` was ignored, so the file `submit_cran()` writes would otherwise be bundled into the tarball.
- Refreshed `cran-comments.md` (was still `0.6.1.9900`), fixed the two `inst/JOSS/paper.bib` URLs `urlchecker` flagged, and corrected en-GB spellings in `NEWS.md` (`Language: en-US`).

## Verification

Against nlist 0.5.0 plus CRAN chk 0.10.0, extras 0.10.0, term 0.3.7, universals 0.0.5:

- `devtools::test()` - full suite passes.
- `devtools::check(manual = TRUE)` - 0 errors, 0 warnings, 1 note. The note is `Skipping checking HTML validation: 'tidy' doesn't look like recent enough HTML Tidy`, a local macOS toolchain artifact rather than a package issue.
- `spelling::spell_check_package()` - clean.
- `urlchecker::url_check()` - clean.
- `air format --check .` - clean.
- CI: all 9 checks pass (R-CMD-check on ubuntu release/devel/oldrel-1, macOS, Windows, plus check-no-suggests, pkgdown, test-coverage).

## Not done here

- **This cannot be submitted until nlist 0.5.0 is on CRAN** (submitted 2026-08-27).
- `devtools::build_readme()` fails because pak cannot solve `nlist (>= 0.5.0)` from CRAN. Re-run it at submission time; no README content changes are pending.
- `devtools::check_win_devel()`, R-hub, and `revdepcheck::revdep_check()` still to run against 0.7.0.
- **Remove the temporary `Remotes: poissonconsulting/nlist`** once nlist 0.5.0 is on CRAN.
- Setting `Version: 0.7.0` on `main` will make the daily `fledge-bump` workflow open PRs bumping to `0.7.0.9000`. Those should be closed (or the schedule paused) until CRAN accepts, otherwise new "Same as previous version" stub sections will accumulate above the 0.7.0 heading.

## Notes for follow-up

- `library(mcmcr)` emits `Registered S3 method overwritten by 'mcmcr': as.mcmc.nlists from nlist`. `R CMD check` does not flag it, but it is a visible wart worth resolving separately.
- `inst/JOSS/paper.bib` has an `rpdo` entry whose `url` points at checkr's CRAN page. I only canonicalized the URL rather than guessing the intended target, since changing it alters the citation.

Refs #86
