### PR TITLE
Bump version to 0.7.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcmcr
 Title: Manipulate MCMC Samples
-Version: 0.7.0
+Version: 0.7.0.9000
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-<!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
+<!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
+
+# mcmcr 0.7.0.9000
+
+- Switching to development version.
+
 
 # mcmcr 0.7.0
 


### PR DESCRIPTION
Returns the package to a development version after mcmcr 0.7.0 was published on CRAN (2026-08-30).

Produced with `fledge::bump_version(which = "dev")`; the `fledge-tag-on-merge` workflow tags `v0.7.0.9000` once this merges.

Refs #86