### PR TITLE
Fix along handling in bind_dimensions() and combine_dimensions()

### DIFF
--- a/R/bind-dimensions-n.R
+++ b/R/bind-dimensions-n.R
@@ -50,6 +50,8 @@ bind_dimensions_n.mcmcr <- function(...) {
     return(x[[1]])
   }
 
+  x <- lapply(x, sort)
+
   pdims <- lapply(x, pdims)
   if (!all(vapply(pdims, identical, TRUE, pdims[[1]]))) {
     abort_chk("all objects must have the same parameter dimensions")

--- a/R/bind-dimensions.R
+++ b/R/bind-dimensions.R
@@ -5,7 +5,9 @@
 #'
 #' @inheritParams params
 #' @param x An MCMC object.
-#' @param along A count (or NULL) indicating the parameter dimension to bind along.
+#' @param along A count (or NULL) indicating the parameter dimension to bind
+#' along. For an [mcmcr-object()] it may also be a vector with one value per
+#' parameter, in the order the parameters occur in `x`.
 #' @seealso [universals::bind_chains()]
 #' @family bind
 #' @export
@@ -40,10 +42,13 @@ bind_dimensions.mcmcarray <- function(x, x2, along = NULL, ...) {
 
 #' @export
 bind_dimensions.mcmcr <- function(x, x2, along = NULL, ...) {
-  chk_s3_class(x, "mcmcr")
+  chk_s3_class(x2, "mcmcr")
   if (!is.null(along)) {
     chk_whole_numeric(along)
     chk_subset(length(along), c(1, npars(x)))
+    if (length(along) > 1) {
+      along <- along[order(pars(x))]
+    }
   }
 
   x <- sort(x)

--- a/R/combine-dimensions.R
+++ b/R/combine-dimensions.R
@@ -59,7 +59,7 @@ combine_dimensions.mcmcr <- function(x, fun = mean, along = NULL, ...) {
   if (!is.null(along)) {
     chk_whole_numeric(along)
     chk_not_any_na(along)
-    chk_identical(length(along), c(1L, length(x)))
+    chk_subset(length(along), c(1L, length(x)))
     if (length(along) == 1L) {
       chk_range(along, c(1L, min(lengths)))
     } else {

--- a/man/bind_dimensions.Rd
+++ b/man/bind_dimensions.Rd
@@ -11,7 +11,9 @@ bind_dimensions(x, x2, along = NULL, ...)
 
 \item{x2}{a second MCMC object.}
 
-\item{along}{A count (or NULL) indicating the parameter dimension to bind along.}
+\item{along}{A count (or NULL) indicating the parameter dimension to bind
+along. For an \code{\link[=mcmcr-object]{mcmcr-object()}} it may also be a vector with one value per
+parameter, in the order the parameters occur in \code{x}.}
 
 \item{...}{Unused.}
 }

--- a/tests/testthat/test-bind-dimensions-n.R
+++ b/tests/testthat/test-bind-dimensions-n.R
@@ -17,3 +17,15 @@ test_that("bind_dimensions_n.mcmcr", {
     list(alpha = c(2L, 3L), beta = c(2L, 2L, 3L), sigma = c(1L, 3L))
   )
 })
+
+test_that("bind_dimensions_n.mcmcr binds parameters that are not sorted", {
+  x <- structure(
+    list(z = mcmcr_example$alpha, a = mcmcr_example$beta),
+    class = "mcmcr"
+  )
+
+  expect_identical(
+    pdims(bind_dimensions_n(x, x)),
+    list(a = c(2L, 2L, 2L), z = c(2L, 2L))
+  )
+})

--- a/tests/testthat/test-bind-dimensions.R
+++ b/tests/testthat/test-bind-dimensions.R
@@ -22,3 +22,23 @@ test_that("bind_dimensions", {
     )
   )
 })
+
+test_that("bind_dimensions.mcmcr matches along to the parameters of x", {
+  x <- structure(
+    list(z = mcmcr_example$alpha, a = mcmcr_example$beta),
+    class = "mcmcr"
+  )
+
+  expect_identical(
+    pdims(bind_dimensions(x, x, along = c(1L, 2L))),
+    list(a = c(2L, 4L), z = 4L)
+  )
+})
+
+test_that("bind_dimensions.mcmcr checks the class of x2", {
+  expect_error(
+    bind_dimensions(mcmcr_example, mcmcr_example$alpha),
+    "^`x2` must inherit from S3 class 'mcmcr'",
+    class = "chk_error"
+  )
+})

--- a/tests/testthat/test-combine-dimensions.R
+++ b/tests/testthat/test-combine-dimensions.R
@@ -50,3 +50,19 @@ test_that("combine_dimensions.mcmcr", {
     ignore_attr = FALSE
   )
 })
+
+test_that("combine_dimensions.mcmcr accepts along of length 1 or npars", {
+  expect_identical(
+    pdims(combine_dimensions(mcmcr_example, along = 1L)),
+    list(alpha = 1L, beta = 2L, sigma = 1L)
+  )
+  expect_identical(
+    pdims(combine_dimensions(mcmcr_example, along = c(1L, 2L, 1L))),
+    list(alpha = 1L, beta = 2L, sigma = 1L)
+  )
+  expect_error(
+    combine_dimensions(mcmcr_example, along = c(1L, 2L)),
+    "^`length\\(along\\)` must match 1 or 3",
+    class = "chk_error"
+  )
+})


### PR DESCRIPTION
Fixes the three `along`-related defects found in the review of `R/`. Each change has a regression test that was written first and confirmed failing against `main`.

## #91 - `bind_dimensions()` applied `along` in the wrong order

`bind_dimensions.mcmcr()` sorts `x` and `x2` by parameter name but left `along` in the caller's order, so the two silently misaligned:

```r
x <- structure(list(z = mcmcr_example$alpha, a = mcmcr_example$beta), class = "mcmcr")
pdims(bind_dimensions(x, x, along = c(1L, 2L)))
# before: $a 4 2   $z 2 2      <- a bound along 1, z along 2
# after:  $a 2 4   $z 4        <- z bound along 1, a along 2, as asked
```

`along` is now permuted by `order(pars(x))` before the sort.

`bind_dimensions_n.mcmcr()` inherited the same defect through the `along` it derives from the unsorted first object; it now sorts the objects before deriving `along`, so an mcmcr whose parameters are not alphabetical no longer fails with `abind: along must be between 0 and 4`. Sorting first also makes its parameter-dimension equality check insensitive to parameter order, matching `bind_dimensions()`.

## #94 - `bind_dimensions.mcmcr()` checked `x` instead of `x2`

`chk_s3_class(x, "mcmcr")` is a no-op under dispatch. A non-mcmcr `x2` previously surfaced as `` `x` and `x2` must have the same parameters. ``; it now gives the intended class error, matching `bind_chains.mcmcr()`, `bind_iterations.mcmcr()` and `combine_samples.mcmcr()`.

## #90 - `combine_dimensions(along = )` always errored for mcmcr

`chk_identical(length(along), c(1L, length(x)))` compared a length-1 integer against a length-2 vector, so no value of `along` could pass. Now `chk_subset()`, as in `bind_dimensions.mcmcr()`. The `min`/`max` range branches below it are reachable for the first time.

## Tests

`[ FAIL 0 | WARN 0 | SKIP 0 | PASS 473 ]` (was 467). Four new tests, all confirmed red before the fix:

- `bind_dimensions.mcmcr matches along to the parameters of x`
- `bind_dimensions.mcmcr checks the class of x2`
- `bind_dimensions_n.mcmcr binds parameters that are not sorted`
- `combine_dimensions.mcmcr accepts along of length 1 or npars`

The `@param along` documentation now states that a vector follows the parameter order of `x`.

Closes #90
Closes #91
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)