### PR TITLE
Check the class of x2 in bind_chains.mcmc.list() and fix the ess() title

### DIFF
--- a/R/bind-chains.R
+++ b/R/bind-chains.R
@@ -44,9 +44,7 @@ bind_chains.mcmc <- function(x, x2, ...) {
 #' @inherit universals::bind_chains
 #' @export
 bind_chains.mcmc.list <- function(x, x2, ...) {
-  if (!vld_s3_class(x, "mcmc") && !vld_s3_class(x, "mcmc.list")) {
-    chkor_vld(vld_s3_class(x, "mcmc"), vld_s3_class(x, "mcmc.list"))
-  }
+  chkor_vld(vld_s3_class(x2, "mcmc"), vld_s3_class(x2, "mcmc.list"))
 
   x <- sort(x)
   x2 <- sort(x2)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,4 @@
-#' P-Value
-#' effective sample size
+#' Effective Sample Size
 #'
 #' Calculates the effective sample size based on [esr()].
 #'

--- a/man/ess.Rd
+++ b/man/ess.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/utils.R
 \name{ess}
 \alias{ess}
-\title{P-Value
-effective sample size}
+\title{Effective Sample Size}
 \usage{
 ess(x, by = "all", as_df = FALSE)
 }

--- a/tests/testthat/test-bind-chains.R
+++ b/tests/testthat/test-bind-chains.R
@@ -75,3 +75,11 @@ test_that("bind_chains.mcmc", {
     class = "chk_error"
   )
 })
+
+test_that("bind_chains.mcmc.list checks the class of x2", {
+  expect_error(
+    bind_chains(as.mcmc.list(mcmcr_example), mcmcr_example),
+    "^At least one of the following conditions must be met:",
+    class = "chk_error"
+  )
+})


### PR DESCRIPTION
Follow-up to #97, clearing the last class-check bug and the documentation defect from the review.

## #92 - `bind_chains.mcmc.list()` validated `x` instead of `x2`

The guard tested `x`, which S3 dispatch already guarantees is an `mcmc.list`, so it was always `FALSE` and `x2` was never checked:

```r
bc <- bind_chains(as.mcmc.list(mcmcr_example), mcmcr_example)
class(bc)
#> [1] "mcmc.list"
unique(vapply(bc, function(e) class(e)[1], ""))
#> [1] "mcmc"      "mcmcarray"     <- structurally invalid, no warning
```

Now `chkor_vld(vld_s3_class(x2, "mcmc"), vld_s3_class(x2, "mcmc.list"))`, which also drops the redundant `if` wrapper. A bad `x2` gets the standard chk message:

```
At least one of the following conditions must be met:
* `x2` must inherit from S3 class 'mcmc', not S3 class 'mcmcr'.
* `x2` must inherit from S3 class 'mcmc.list', not S3 class 'mcmcr'.
```

## #96 - stray `P-Value` title on `ess()`

`R/utils.R` had an orphaned `#' P-Value` line above the real title, so `man/ess.Rd` read `\title{P-Value effective sample size}`. Now `\title{Effective Sample Size}`.

## Tests

`[ FAIL 0 | WARN 0 | SKIP 0 | PASS 474 ]` (was 473). One new test, confirmed red before the fix ("Expected ... to throw a error with class <chk_error>"): `bind_chains.mcmc.list checks the class of x2`.

Closes #92
Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)