### PR TITLE
Enforce uniquely named parameters in vld_mcmcr()

### DIFF
--- a/R/vld.R
+++ b/R/vld.R
@@ -35,6 +35,8 @@ vld_mcmcarray <- function(x) {
 vld_mcmcr <- function(x) {
   vld_s3_class(x, "mcmcr") &&
     vld_list(x) &&
+    vld_named(x) &&
+    vld_unique(names(x)) &&
     vld_all(x, vld_mcmcarray) &&
     vld_all_identical(lapply(x, nchains)) &&
     vld_all_identical(lapply(x, niters))

--- a/tests/testthat/test-chk.R
+++ b/tests/testthat/test-chk.R
@@ -57,3 +57,18 @@ test_that("chk_mcmcrs", {
     class = "chk_error"
   )
 })
+
+test_that("chk_mcmcr checks parameter names", {
+  x <- structure(list(mcmcr_example$alpha), class = "mcmcr")
+  expect_error(chk_mcmcr(x), "^`x` must be named[.]$", class = "chk_error")
+
+  x <- structure(
+    list(alpha = mcmcr_example$alpha, alpha = mcmcr_example$alpha),
+    class = "mcmcr"
+  )
+  expect_error(
+    chk_mcmcr(x),
+    "^names\\(`x`\\) must be unique[.]$",
+    class = "chk_error"
+  )
+})

--- a/tests/testthat/test-vld.R
+++ b/tests/testthat/test-vld.R
@@ -20,3 +20,11 @@ test_that("vld_mcmcr", {
   expect_false(vld_mcmcr(list(x = 1)))
   expect_true(vld_mcmcr(as.mcmcr(list(x = 1))))
 })
+
+test_that("vld_mcmcr requires uniquely named parameters", {
+  expect_false(vld_mcmcr(structure(list(mcmcr_example$alpha), class = "mcmcr")))
+  expect_false(vld_mcmcr(structure(
+    list(alpha = mcmcr_example$alpha, alpha = mcmcr_example$alpha),
+    class = "mcmcr"
+  )))
+})


### PR DESCRIPTION
Last of the review findings. `vld_mcmcr()` omitted the name checks, so `chk_mcmcr()` returned early through its `if (vld_mcmcr(x)) return(invisible())` fast path and its own `chk_named()` / `vld_unique(names(x))` lines were unreachable:

```r
b <- mcmcr_example$alpha
chk_mcmcr(structure(list(alpha = b, alpha = b), class = "mcmcr"))   # before: accepted
chk_mcmcr(structure(list(b), class = "mcmcr"))                     # before: accepted
```

The "uniquely named" invariant documented in `mcmcr-object.R` was therefore unenforced, and a duplicate-named mcmcr misbehaves downstream — `subset(x, pars = "a")` returns only one element, and the `intersect(pars(x), pars(x2))` guard in `bind_parameters()` can be evaded.

`vld_mcmcr()` now includes `vld_named(x) && vld_unique(names(x))`, placed to mirror the order of `chk_mcmcr()`'s own checks so the error messages come out in the intended sequence:

```
`x` must be named.
names(`x`) must be unique.
```

`vld_mcmcrs()` needs no change — it validates its elements through `vld_all(x, vld_mcmcr)`, so it inherits this, and an `mcmcrs` object carries no naming invariant of its own.

## Behaviour change

This tightens two exported functions, `vld_mcmcr()` and `chk_mcmcr()`. Objects that were silently accepted now fail validation, which is the intent, but it is a user-visible change and the commit message is worded for the NEWS entry. Worth a `revdepcheck::revdep_check()` before the next release, since mcmcderive, missingHE and nlist all consume mcmcr objects.

## Tests

`[ FAIL 0 | WARN 0 | SKIP 0 | PASS 478 ]` (was 474). Four new expectations across two tests, all confirmed red before the fix:

- `vld_mcmcr requires uniquely named parameters` (unnamed and duplicate-named both returned `TRUE`)
- `chk_mcmcr checks parameter names` (neither case threw)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)